### PR TITLE
UX-1571 Define base theme settings

### DIFF
--- a/_src/static/sass/utilities/_variables.scss
+++ b/_src/static/sass/utilities/_variables.scss
@@ -25,12 +25,12 @@ $baseline-horizontal:    $baseline;
 // color: config
 $transparent:       rgba(0, 0, 0, 0);
 
+$blue:              rgb(0, 162, 227);
+$pink:              rgb(183, 37, 103);
 $gray:              rgb(127, 127, 127);
 $red:               rgb(178, 6, 16);
 $yellow:            rgb(237, 189, 60);
 $green:             rgb(37, 184, 90);
-$blue:              rgb(0, 162, 227);
-$pink:              rgb(183, 37, 103);
 
 $brand-primary:     $blue;
 $brand-secondary:   $pink;

--- a/_src/themes/mit/static/sass/_utilities.scss
+++ b/_src/themes/mit/static/sass/_utilities.scss
@@ -5,7 +5,58 @@
 // ----------------------------
 
 
-// reset of links
+// ----------------------------
+// #COLORS
+// ----------------------------
+$mit-maroon:                    rgba(163, 31, 52, 1.0);
+$dark-gray:                     rgba(138, 139, 140, 1.0);
+$light-gray:                    rgba(194, 192, 191, 1.0);
+
+$brand-primary:                 $mit-maroon;
+$brand-secondary:               $dark-gray;
+$brand-accent:                  $light-gray;
+
+
+// ----------------------------
+// #TYPOGRAPHY
+// Font families
+// ----------------------------
+@import url("http://fonts.googleapis.com/css?family=Lato:400,900,400italic");
+
+// Font families
+$font-family-sans-serif: 'Lato', sans-serif;
+
+
+// ----------------------------
+// #APPLICATIONS
+// Scaffolding
+// Base text settings
+// Links
+// Headings
+// ----------------------------
+// Scaffolding
+$view-bg: rgba(235, 235, 235, 1.0);
+
+// Base text settings
+$text-base-color: $dark-gray;
+$text-base-focus-color: $brand-primary;
+
+// Links
+$link-color: $brand-primary;
+$link-focus-color: saturate($brand-primary, 20%);
+$link-visited-color: desaturate($brand-primary, 20%);
+
+// Headings
+$headings-base-color: $dark-gray;
+$headings-primary-color: $black;
+$headings-secondary-color: $light-gray;
+
+
+// ----------------------------
+// #EXTENDS
+// Links
+// ----------------------------
+// Links
 %link {
     @include transition(all timing(x-fast) ease-in-out);
     border-bottom: rem(1) solid $transparent;

--- a/_src/themes/mit/static/sass/_utilities.scss
+++ b/_src/themes/mit/static/sass/_utilities.scss
@@ -1,0 +1,22 @@
+// ----------------------------
+// MIT (Example file)
+// This file provides utility overrides for base/_utilities in the main platform compile.
+// It allows instutions to provide alternative values when displaying the application.
+// ----------------------------
+
+
+// reset of links
+%link {
+    @include transition(all timing(x-fast) ease-in-out);
+    border-bottom: rem(1) solid $transparent;
+    color: palette(primary, base);
+    text-decoration: none;
+
+    // STATE: hover, active, focus
+    &:hover,
+    &:active,
+    &:focus {
+        border-bottom-color: palette(primary, sat);
+        color: palette(primary, sat);
+    }
+}

--- a/_src/themes/mit/static/sass/_variables.scss
+++ b/_src/themes/mit/static/sass/_variables.scss
@@ -1,0 +1,47 @@
+// ----------------------------
+// MIT (Example file)
+// This file provides utility overrides for base/_utilities in the main platform compile.
+// It allows instutions to provide alternative values when displaying the application.
+// ----------------------------
+
+
+// ----------------------------
+// #COLORS
+// ----------------------------
+$mit-maroon:                    rgba(163, 31, 52, 1.0);
+$dark-gray:                     rgba(138, 139, 140, 1.0);
+$light-gray:                    rgba(194, 192, 191, 1.0);
+
+$brand-primary:                 $mit-maroon;
+$brand-secondary:               $dark-gray;
+$brand-accent:                  $light-gray;
+
+
+// ----------------------------
+// #TYPOGRAPHY
+// ----------------------------
+@import url("http://fonts.googleapis.com/css?family=Lato:400,900,400italic");
+
+// Font families
+$font-family-sans-serif: 'Lato', sans-serif;
+
+
+// ----------------------------
+// #APPLICATIONS
+// ----------------------------
+// Scaffolding
+$view-bg: rgba(235, 235, 235, 1.0);
+
+// Base text settings
+$text-base-color: $dark-gray;
+$text-base-focus-color: $brand-primary;
+
+// Links
+$link-color: $brand-primary;
+$link-focus-color: saturate($brand-primary, 20%);
+$link-visited-color: desaturate($brand-primary, 20%);
+
+// Headings
+$headings-base-color: $dark-gray;
+$headings-primary-color: $black;
+$headings-secondary-color: $light-gray;


### PR DESCRIPTION
- - -
_Note: this branch is not to be merged. It serves as an example for theming and will be updated over time to reflect additions to the base pattern library partials._
- - -

# Theming the edX platform
The files included in this branch serve as a reference for _how_ to create themes. Creating a theme does the following:
* provides override values to existing variables in the edX platform
* provides additional values for use, extending the platform

## Using the partials
This branch includes a `_utilities.scss` partial and a `_variables.scss` partial. These two files include example styles that override the platform styles. Specifically in `_variables.scss` we're using different brand colors (in this case, specific to MIT), a different typeface, and a few other styles that are to differ from the platform styles.

Only variable or style overrides need to be included in theme partials. Not specifying a value will let theme use the platform styles.