### PR TITLE
Changing links from # to edx.org

### DIFF
--- a/_posts/elements/2015-04-09-buttons.md
+++ b/_posts/elements/2015-04-09-buttons.md
@@ -98,8 +98,8 @@ info: Buttons should be used for performing actions within the edX environment. 
 
 <h3 class="hd-6 example-set-hd">Links</h3>
 <div class="example-set">
-    <a href="#">A normal link</a>
-    <a href="#" class="btn btn-default btn-base">Link as Button Base</a>
-    <a href="#" class="btn btn-default btn-large">Link as Button Large</a>
-    <a href="#" class="btn btn-default btn-small">Link as Button Small</a>
+    <a href="http://www.edx.org">A normal link</a>
+    <a href="http://www.edx.org" class="btn btn-default btn-base">Link as Button Base</a>
+    <a href="http://www.edx.org" class="btn btn-default btn-large">Link as Button Large</a>
+    <a href="http://www.edx.org" class="btn btn-default btn-small">Link as Button Small</a>
 </div>


### PR DESCRIPTION
@talbs This really quick PR changes the link/button `href` from `#` to `edx.org`.