### PR TITLE
PL: headings + copy sync up

### DIFF
--- a/_posts/elements/2015-03-25-headings.md
+++ b/_posts/elements/2015-03-25-headings.md
@@ -19,46 +19,46 @@ info: Headings are used to define important topics and section content into dige
 
 <div class="example-set">
     <h1 class="hd-1">The Frozen Dreams</h1>
-    <p>That behind that one laconically began when <a href="#">destructively and save goat gorilla</a> hence and mislaid idiotic thus after yikes alas including and emu absent chose aboard into thinly along fragrant infallible cracked where however thin about ouch different hung much hello nakedly gnu input dolorous the wrung.</p>
+    <p class="copy copy-lead">That behind that one laconically began when <a href="#">destructively and save goat gorilla</a> hence and mislaid idiotic thus after yikes alas including and emu absent chose aboard into thinly along fragrant infallible cracked where however thin about ouch different hung much hello nakedly gnu input dolorous the wrung.</p>
 
     <h1 class="hd-1 emphasized">The Mage of the Flying</h1>
-    <p>Blunt sprang haggardly wow crud one alas familiarly a far dear much some more hey far within on less obediently then proved since this more repusively much ouch along peered raving far wherever gazelle so seal rooster poetically far.</p>
+    <p class="copy copy-lead">Blunt sprang haggardly wow crud one alas familiarly a far dear much some more hey far within on less obediently then proved since this more repusively much ouch along peered raving far wherever gazelle so seal rooster poetically far.</p>
 
     <h1 class="hd-1 de-emphasized">The Snow's Heat</h1>
-    <p>Flexed far one sloth angelfish dear groggy abashedly dynamic tendentious off and tacitly crud wrote so as grabbed jeez dear or invidious crud lobster abject unlike that rational eagle alas but swore about far far knew more far and because opposite well dim diverse in jeez inside by blissfully.</p>
+    <p class="copy copy-lead">Flexed far one sloth angelfish dear groggy abashedly dynamic tendentious off and tacitly crud wrote so as grabbed jeez dear or invidious crud lobster abject unlike that rational eagle alas but swore about far far knew more far and because opposite well dim diverse in jeez inside by blissfully.</p>
 </div>
 
 <div class="example-set">
     <h2 class="hd-2">Thorn in the Light</h2>
-    <p>Less hugely and towards goodness hello jeez less gosh outdid perilous abominable off expeditious directed nightingale exquisitely toward when since unihibitedly the one vengefully blatant owing far exited that much far and rebound hence grimaced one crud preparatory forward <a href="#">while until superb</a> poignantly jeepers plentiful friskily.</p>
+    <p class="copy copy-large">Less hugely and towards goodness hello jeez less gosh outdid perilous abominable off expeditious directed nightingale exquisitely toward when since unihibitedly the one vengefully blatant owing far exited that much far and rebound hence grimaced one crud preparatory forward <a href="#">while until superb</a> poignantly jeepers plentiful friskily.</p>
 
     <h2 class="hd-2 emphasized">Mage in the Future</h2>
-    <p>Contrary one boundlessly salaciously from forecast close taped haphazardly lucratively naive tautly excepting the far hello ouch about according coarse far well copious as rough much and less through darn considering insect hysteric misunderstood convincingly permissive where.</p>
+    <p class="copy copy-large">Contrary one boundlessly salaciously from forecast close taped haphazardly lucratively naive tautly excepting the far hello ouch about according coarse far well copious as rough much and less through darn considering insect hysteric misunderstood convincingly permissive where.</p>
 
     <h2 class="hd-2 de-emphasized">The Forgotten Wind</h2>
-    <p>Between jeepers in a some the crud far less alertly a beside jeepers much goldfish shivered fanatically far and before or acute groundhog madly cat or hawk comprehensively conically wrung in out that far far this antelope overlay.</p>
+    <p class="copy copy-large">Between jeepers in a some the crud far less alertly a beside jeepers much goldfish shivered fanatically far and before or acute groundhog madly cat or hawk comprehensively conically wrung in out that far far this antelope overlay.</p>
 </div>
 
 <div class="example-set">
     <h3 class="hd-3">Slaves of Birch</h3>
-    <p>Sourly browbeat yikes cantankerous jeepers far gosh crucially darn that so this the <a href="#">grumbled where jeez</a> and bid around the by warthog swung pending this stared hired and breezy stank bald a as some however dear since more more.</p>
+    <p class="copy copy-base">Sourly browbeat yikes cantankerous jeepers far gosh crucially darn that so this the <a href="#">grumbled where jeez</a> and bid around the by warthog swung pending this stared hired and breezy stank bald a as some however dear since more more.</p>
 
     <h3 class="hd-3 emphasized">The Heat's Game</h3>
-    <p>Next stupid and on stuffily bald because domestically grew factious sewed outgrew coughed hello this overcame violent briefly much more improperly prior more experimental jeepers that egotistically licentiously unlike while darn regarding slowly mandrill until this dear on that mischievous before that insincere robin in nervelessly and.</p>
+    <p class="copy copy-base">Next stupid and on stuffily bald because domestically grew factious sewed outgrew coughed hello this overcame violent briefly much more improperly prior more experimental jeepers that egotistically licentiously unlike while darn regarding slowly mandrill until this dear on that mischievous before that insincere robin in nervelessly and.</p>
 
     <h3 class="hd-3 de-emphasized">The Slave of the Wind</h3>
-    <p>Soothing some sluggishly a koala when cassowary and onto therefore one a dragonfly and a fixedly caustic hen tacit away far a until hello alas pangolin sensibly ambiguously titilatingly much cardinal one vacuously whispered overabundant ouch more.</p>
+    <p class="copy copy-base">Soothing some sluggishly a koala when cassowary and onto therefore one a dragonfly and a fixedly caustic hen tacit away far a until hello alas pangolin sensibly ambiguously titilatingly much cardinal one vacuously whispered overabundant ouch more.</p>
 </div>
 
 <div class="example-set">
     <h4 class="hd-4">Crying in the Courage</h4>
-    <p>And gosh and jovial this much but angelfish after and <a href="#">far but inside and this roadrunner</a> that this oh when yikes therefore far amidst goldfinch darn lazily inside a abashed hello so after nutria gosh much and mallard out shoddily sang more the genial close destructively on then as less.</p>
+    <p class="copy copy-base">And gosh and jovial this much but angelfish after and <a href="#">far but inside and this roadrunner</a> that this oh when yikes therefore far amidst goldfinch darn lazily inside a abashed hello so after nutria gosh much and mallard out shoddily sang more the genial close destructively on then as less.</p>
 
     <h4 class="hd-4 emphasized">Lovely Year</h4>
-    <p>Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward together like angelfish fastidious as lingeringly among that fitted crud cried orca strove on and hello far kissed octopus regarding confused less one and the oh.</p>
+    <p class="copy copy-base">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward together like angelfish fastidious as lingeringly among that fitted crud cried orca strove on and hello far kissed octopus regarding confused less one and the oh.</p>
 
     <h4 class="hd-4 de-emphasized">The Fallen Legacy</h4>
-    <p>Lackadaisical fallibly next annoyingly shrugged and copiously inexhaustibly rode however peculiar more this spuriously flagrantly vigilantly crud more woolly effectively macaw among cardinal more alas darn near a conic primly more truly tarantula hello inventoried.</p>
+    <p class="copy copy-base">Lackadaisical fallibly next annoyingly shrugged and copiously inexhaustibly rode however peculiar more this spuriously flagrantly vigilantly crud more woolly effectively macaw among cardinal more alas darn near a conic primly more truly tarantula hello inventoried.</p>
 </div>
 
 <div class="example-set">
@@ -74,22 +74,22 @@ info: Headings are used to define important topics and section content into dige
 
 <div class="example-set">
     <h6 class="hd-6">Future in the Shores</h6>
-    <p><a href="#">Less did black played hey</a> much tore much jeepers tolerable far virtuously the where much cocky during goodness boa less celestial dear hence far less overshot sexual trying some much up slovenly eternally forward flustered logic compulsively some and inside but.</p>
+    <p class="copy copy-meta"><a href="#">Less did black played hey</a> much tore much jeepers tolerable far virtuously the where much cocky during goodness boa less celestial dear hence far less overshot sexual trying some much up slovenly eternally forward flustered logic compulsively some and inside but.</p>
 
     <h6 class="hd-6 emphasized">The Emerald Servant</h6>
-    <p>Much and mandrill hey and guinea elephant debonair and before under complete in hippopotamus shot human precisely the the and uneasy as beside darn less overdid much far unblushingly drew favorable and limp yikes and dear cold and sentimentally teasing that since moronically oh eagle knew boyish pangolin.</p>
+    <p class="copy copy-meta">Much and mandrill hey and guinea elephant debonair and before under complete in hippopotamus shot human precisely the the and uneasy as beside darn less overdid much far unblushingly drew favorable and limp yikes and dear cold and sentimentally teasing that since moronically oh eagle knew boyish pangolin.</p>
 
     <h6 class="hd-6 de-emphasized">Destruction in the Storms</h6>
-    <p>Instead this well dwelled to combed through less immeasurably the that flagrant jeez fanatically astride and treacherous outrageous much fish more antagonistic a toward charming dragonfly noiselessly far irrespective laboriously parrot beyond much squid well some that annoyingly severe but much slapped but liberally diverse.</p>
+    <p class="copy copy-meta">Instead this well dwelled to combed through less immeasurably the that flagrant jeez fanatically astride and treacherous outrageous much fish more antagonistic a toward charming dragonfly noiselessly far irrespective laboriously parrot beyond much squid well some that annoyingly severe but much slapped but liberally diverse.</p>
 </div>
 
 <div class="example-set">
     <h6 class="hd-7">Slaves of Birch</h6>
-    <p>Sourly browbeat yikes cantankerous jeepers far gosh crucially darn that so this the <a href="#">grumbled where jeez</a> and bid around the by warthog swung pending this stared hired and breezy stank bald a as some however dear since more more.</p>
+    <p class="copy copy-micro">Sourly browbeat yikes cantankerous jeepers far gosh crucially darn that so this the <a href="#">grumbled where jeez</a> and bid around the by warthog swung pending this stared hired and breezy stank bald a as some however dear since more more.</p>
 
     <h5 class="hd-7 emphasized">The Heat's Game</h5>
-    <p>Next stupid and on stuffily bald because domestically grew factious sewed outgrew coughed hello this overcame violent briefly much more improperly prior more experimental jeepers that egotistically licentiously unlike while darn regarding slowly mandrill until this dear on that mischievous before that insincere robin in nervelessly and.</p>
+    <p class="copy copy-micro">Next stupid and on stuffily bald because domestically grew factious sewed outgrew coughed hello this overcame violent briefly much more improperly prior more experimental jeepers that egotistically licentiously unlike while darn regarding slowly mandrill until this dear on that mischievous before that insincere robin in nervelessly and.</p>
 
     <h4 class="hd-7 de-emphasized">The Slave of the Wind</h4>
-    <p>Soothing some sluggishly a koala when cassowary and onto therefore one a dragonfly and a fixedly caustic hen tacit away far a until hello alas pangolin sensibly ambiguously titilatingly much cardinal one vacuously whispered overabundant ouch more.</p>
+    <p class="copy copy-micro">Soothing some sluggishly a koala when cassowary and onto therefore one a dragonfly and a fixedly caustic hen tacit away far a until hello alas pangolin sensibly ambiguously titilatingly much cardinal one vacuously whispered overabundant ouch more.</p>
 </div>


### PR DESCRIPTION
This work updates our doc site headings example to use copy elements for context