### PR TITLE
FIX: Correct Path so Favicon Displays on All PL Doc Views

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link rel="shortcut icon" href="favicon.ico"/>
+    <link rel="shortcut icon" href="{{ site.baseurl }}favicon.ico">
 
     <title>
         {% if page.title == "Home" %}


### PR DESCRIPTION
This work sets favicon path to be site/root-relative so pages like http://ux.edx.org/elements/buttons/ can render it as well.