### PR TITLE
Set Up: Watch All Jekyll Files

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -71,7 +71,9 @@ module.exports = {
     jekyll: {
         home: 'index.html',
         posts: '_posts/*',
-        layouts: '_layouts/*.html'
+        includes: '_includes/*',
+        examples: 'examples/*',
+        layouts: '_layouts/*'
     }
 };
 

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -14,5 +14,7 @@ gulp.task('watch', ['browserSync'], function() {
     // local
     gulp.watch(config.jekyll.home, ['jekyll-rebuild']);
     gulp.watch(config.jekyll.posts, ['jekyll-rebuild']);
+    gulp.watch(config.jekyll.includes, ['jekyll-rebuild']);
+    gulp.watch(config.jekyll.examples, ['jekyll-rebuild']);
     gulp.watch(config.jekyll.layouts, ['jekyll-rebuild']);
 });


### PR DESCRIPTION
This work changes our local gulp workflow's watch task to watch more Jekyll-based file changes, including:

* HTML/DOM includes
* Layouts
* Example files (in ``/examples/*.html``)

This work should make any local template or copy changes much more efficient.