### PR TITLE
Set Up: Remove Extra Jekyll Build Step from Gulp Default Task

### DIFF
--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -5,7 +5,6 @@ gulp.task( 'default', function() {
     runSequence(
         ['styles', 'scripts', 'images'],
         ['pldoc_styles', 'pldoc_scripts', 'pldoc_images'],
-        'jekyll-build',
         'watch'
     );
 });


### PR DESCRIPTION
This work removes a redundant ``jekyll-build`` task being run as part of our ``default`` gulp task. Jekyll will be kicked off from the ``watch`` task called as part of that ``default`` task.

**Before: Local Terminal Output from Gulp Command**

```
ux-pattern-library :: (master) » gulp                                                                                                              ~/edX/ux-pattern-library
[08:01:27] Using gulpfile ~/edX/ux-pattern-library/gulpfile.js
[08:01:27] Starting 'default'...
[08:01:28] Starting 'styles'...
[08:01:28] Starting 'pldoc_scripts-lint'...
[08:01:28] Starting 'images'...
[08:01:28] Finished 'default' after 25 ms
[08:01:28] gulp-imagemin: Minified 0 images
[08:01:28] Finished 'images' after 20 ms
[08:01:28] Finished 'pldoc_scripts-lint' after 188 ms
[08:01:28] Starting 'scripts'...
[08:01:30] Finished 'scripts' after 2.14 s
[08:01:30] Finished 'styles' after 2.35 s
[08:01:30] Starting 'pldoc_styles'...
[08:01:30] Starting 'pldoc_scripts-lint'...
[08:01:30] Starting 'pldoc_images'...
[08:01:30] gulp-imagemin: Minified 0 images
[08:01:30] Finished 'pldoc_images' after 12 ms
[08:01:30] Finished 'pldoc_scripts-lint' after 91 ms
[08:01:30] Starting 'pldoc_scripts'...
[08:01:30] Finished 'pldoc_scripts' after 115 ms
[08:01:31] Size main-ltr.css : 1.21 kB
[08:01:31] Size main-rtl.css : 1.21 kB
[08:01:31] Finished 'pldoc_styles' after 1.61 s
[08:01:31] Starting 'jekyll-build'...
Configuration file: /Users/btalbot/edX/ux-pattern-library/_config.yml
            Source: /Users/btalbot/edX/ux-pattern-library
       Destination: /Users/btalbot/edX/ux-pattern-library/_site
      Generating...
                    done.
 Auto-regeneration: disabled. Use --watch to enable.
[08:01:37] Finished 'jekyll-build' after 5.99 s
[08:01:37] Starting 'jekyll-build'...
Configuration file: /Users/btalbot/edX/ux-pattern-library/_config.yml
            Source: /Users/btalbot/edX/ux-pattern-library
       Destination: /Users/btalbot/edX/ux-pattern-library/_site
      Generating...
                    done.
 Auto-regeneration: disabled. Use --watch to enable.
[08:01:43] Finished 'jekyll-build' after 5.37 s
[08:01:43] Starting 'browserSync'...
[08:01:43] Finished 'browserSync' after 119 ms
[08:01:43] Starting 'watch'...
[08:01:43] Finished 'watch' after 48 ms
[BS] Access URLs:
 --------------------------------------
       Local: http://localhost:3000
    External: http://18.111.41.226:3000
 --------------------------------------
          UI: http://localhost:3001
 UI External: http://18.111.41.226:3001
 --------------------------------------
[BS] Serving files from: ./_site
```

- - -

**After: Local Terminal Output from Gulp Command**

```
ux-pattern-library :: (master) » gulp                                                                                                              ~/edX/ux-pattern-library
[07:55:14] Using gulpfile ~/edX/ux-pattern-library/gulpfile.js
[07:55:14] Starting 'default'...
[07:55:14] Starting 'styles'...
[07:55:14] Starting 'pldoc_scripts-lint'...
[07:55:14] Starting 'images'...
[07:55:14] Finished 'default' after 20 ms
[07:55:14] gulp-imagemin: Minified 0 images
[07:55:14] Finished 'images' after 14 ms
[07:55:14] Finished 'pldoc_scripts-lint' after 129 ms
[07:55:14] Starting 'scripts'...
[07:55:16] Finished 'styles' after 2 s
[07:55:16] Finished 'scripts' after 1.86 s
[07:55:16] Starting 'pldoc_styles'...
[07:55:16] Starting 'pldoc_scripts-lint'...
[07:55:16] Starting 'pldoc_images'...
[07:55:16] gulp-imagemin: Minified 0 images
[07:55:16] Finished 'pldoc_images' after 11 ms
[07:55:16] Finished 'pldoc_scripts-lint' after 92 ms
[07:55:16] Starting 'pldoc_scripts'...
[07:55:16] Finished 'pldoc_scripts' after 118 ms
[07:55:17] Size main-ltr.css : 1.21 kB
[07:55:17] Size main-rtl.css : 1.21 kB
[07:55:17] Finished 'pldoc_styles' after 1.57 s
[07:55:17] Starting 'jekyll-build'...
Configuration file: /Users/btalbot/edX/ux-pattern-library/_config.yml
            Source: /Users/btalbot/edX/ux-pattern-library
       Destination: /Users/btalbot/edX/ux-pattern-library/_site
      Generating...
                    done.
 Auto-regeneration: disabled. Use --watch to enable.
[07:55:21] Finished 'jekyll-build' after 3.84 s
[07:55:21] Starting 'browserSync'...
[07:55:21] Finished 'browserSync' after 93 ms
[07:55:21] Starting 'watch'...
[07:55:21] Finished 'watch' after 76 ms
[BS] Access URLs:
 --------------------------------------
       Local: http://localhost:3000
    External: http://18.111.41.226:3000
 --------------------------------------
          UI: http://localhost:3001
 UI External: http://18.111.41.226:3001
 --------------------------------------
[BS] Serving files from: ./_site
```

- - -

##### Reviewers

* [x] Usage: @marcotuts  