### PR TITLE
FIX: Remove Grid Debug Utility

### DIFF
--- a/_src/pattern-library/sass/components/_grid.scss
+++ b/_src/pattern-library/sass/components/_grid.scss
@@ -361,15 +361,3 @@ $susy-debug: layout($susy-default show);
         }
     }
 }
-
-
-// ----------------------------
-// #DEBUG
-// ----------------------------
-%grid-debug {
-    @include show-grid();
-}
-
-.grid-debug {
-    @extend %grid-debug;
-}


### PR DESCRIPTION
This work removes the debug grid extend/utility - it is not used and is causing compilation issues