### PR TITLE
FIX - Simplifying Sass baseline/spacing variables

### DIFF
--- a/_src/pattern-library/sass/utilities/_variables.scss
+++ b/_src/pattern-library/sass/utilities/_variables.scss
@@ -23,8 +23,6 @@ $em-base: 16; // deliberately sets bourbon-based em-base (http://bourbon.io/docs
 // ----------------------------
 // grid - baseline
 $baseline:                   20 !default;
-$baseline-vertical:          ($baseline*2) !default;
-$baseline-horizontal:        $baseline !default;
 
 // grid - dimensions
 $grid-max-width:             rem(1170) !default;
@@ -273,25 +271,25 @@ $z-depths: (
 );
 
 $spacing-vertical: (
-    base:       $baseline-vertical,
-    mid-small:  ($baseline-vertical*0.75),
-    small:      ($baseline-vertical/2),
-    x-small:    ($baseline-vertical/4),
-    xx-small:   ($baseline-vertical/8),
-    mid-large:  ($baseline-vertical*1.5),
-    large:      ($baseline-vertical*2),
-    x-large:    ($baseline-vertical*4)
+    base:       ($baseline*2),
+    mid-small:  ($baseline*1.5),
+    small:      ($baseline),
+    x-small:    ($baseline/2),
+    xx-small:   ($baseline/4),
+    mid-large:  ($baseline*3),
+    large:      ($baseline*4),
+    x-large:    ($baseline*8)
 );
 
 $spacing-horizontal: (
-    base:       $baseline-horizontal,
-    mid-small:  ($baseline-horizontal*0.75),
-    small:      ($baseline-horizontal/2),
-    x-small:    ($baseline-horizontal/4),
-    xx-small:   ($baseline-horizontal/8),
-    mid-large:  ($baseline-horizontal*1.5),
-    large:      ($baseline-horizontal*2),
-    x-large:    ($baseline-horizontal*4)
+    base:       $baseline,
+    mid-small:  ($baseline*0.75),
+    small:      ($baseline/2),
+    x-small:    ($baseline/4),
+    xx-small:   ($baseline/8),
+    mid-large:  ($baseline*1.5),
+    large:      ($baseline*2),
+    x-large:    ($baseline*4)
 );
 
 


### PR DESCRIPTION
This work, based off of good feedback from @frrrances, simplifies how we use ``$baseline`` and the ``spacing-vertical/horizontal``settings in the PL. 

Essentially, ``$baseline-vertical`` and ``$baseline-horizontal`` are not needed and we can just scale vertical and horizontal spacing within the $spacing-`` sass maps.

- - -

##### Reviewers

* [x] FED - @frrrances 