### PR TITLE
PL Doc: reference registered edx-pattern-library Bower Package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,6 @@
     "bower_components"
   ],
   "dependencies": {
-    "edx-pattern-library": "edx/ux-pattern-library#758ebc838cb9a04d4a5fe7ceccf545e4ec434e45"
+    "edx-pattern-library": "~0.2.0"
   }
 }


### PR DESCRIPTION
This quick change points the bower configuration to the officially registered edX Pattern Library Bower package.

- - -

#### Reviewers

* [x] **Bower Package update** - @dsjen 