### PR TITLE
Add emphasized headings and copy extends

### DIFF
--- a/_src/pattern-library/sass/components/_copy.scss
+++ b/_src/pattern-library/sass/components/_copy.scss
@@ -9,17 +9,27 @@
 // ----------------------------
 // #GLOBAL
 // ----------------------------
+
+// broad stroke extend for emphasized/de-emphasized copy
+%copy-emphasized {
+    color: $text-emphasized-color;
+    font-weight: $text-emphasized-font-weight;
+}
+
+%copy-de-emphasized {
+    color: $text-de-emphasized-color;
+    font-weight: $text-de-emphasized-font-weight;
+}
+
 .copy {
     color: $text-base-color;
 
     &.emphasized {
-        color: $text-emphasized-color;
-        font-weight: $text-emphasized-font-weight;
+        @extend %copy-emphasized;
     }
 
     &.de-emphasized {
-        color: $text-de-emphasized-color;
-        font-weight: $text-de-emphasized-font-weight;
+        @extend %copy-de-emphasized;
     }
 }
 
@@ -108,13 +118,3 @@
     @extend %copy-micro;
 }
 
-// broad stroke extend for emphasized/de-emphasized copy
-%copy-emphasized {
-    color: $text-emphasized-color;
-    font-weight: $text-emphasized-font-weight;
-}
-
-%copy-de-emphasized {
-    color: $text-de-emphasized-color;
-    font-weight: $text-de-emphasized-font-weight;
-}

--- a/_src/pattern-library/sass/components/_copy.scss
+++ b/_src/pattern-library/sass/components/_copy.scss
@@ -108,4 +108,13 @@
     @extend %copy-micro;
 }
 
+// broad stroke extend for emphasized/de-emphasized copy
+%copy-emphasized {
+    color: $text-emphasized-color;
+    font-weight: $text-emphasized-font-weight;
+}
 
+%copy-de-emphasized {
+    color: $text-de-emphasized-color;
+    font-weight: $text-de-emphasized-font-weight;
+}

--- a/_src/pattern-library/sass/components/_headings.scss
+++ b/_src/pattern-library/sass/components/_headings.scss
@@ -138,3 +138,9 @@ $headings-count: 8;
         @extend %hd-#{$i};
     }
 }
+
+// broad stroke extend for emphasized heading
+%headings-emphasized {
+    color: $headings-emphasized-color;
+    font-weight: $headings-font-weight-bold;
+}

--- a/_src/pattern-library/sass/components/_headings.scss
+++ b/_src/pattern-library/sass/components/_headings.scss
@@ -17,6 +17,17 @@ $headings-count: 8;
 // ----------------------------
 // #GLOBAL
 // ----------------------------
+
+// broad stroke extend for emphasized/de-emphasized headings
+%headings-emphasized {
+    color: $headings-emphasized-color;
+    font-weight: $headings-font-weight-bold;
+}
+
+%headings-de-emphasized {
+    color: $headings-de-emphasized-color;
+}
+
 .hd-1,
 .hd-2,
 .hd-3,
@@ -26,12 +37,11 @@ $headings-count: 8;
     @extend %reset-headings;
 
     &.emphasized {
-        color: $headings-emphasized-color;
-        font-weight: $headings-font-weight-bold;
+        @extend %headings-emphasized;
     }
 
     &.de-emphasized {
-        color: $headings-de-emphasized-color;
+        @extend %headings-de-emphasized;
     }
 }
 
@@ -137,10 +147,4 @@ $headings-count: 8;
     .hd-#{$i} {
         @extend %hd-#{$i};
     }
-}
-
-// broad stroke extend for emphasized heading
-%headings-emphasized {
-    color: $headings-emphasized-color;
-    font-weight: $headings-font-weight-bold;
 }


### PR DESCRIPTION
**Description**
This small PR adds extends to allow for emphasized copy and headings without needing to add classes to the DOM.

**Reviewers**
- [x] Code: @talbs 
