### PR TITLE
FIX - PL Doc: Correcting scss link paths for elements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ exclude:                    ["node_modules", "gulp", "gulpfile.js", "package.jso
 # Custom vars
 github:
     repo:                   https://github.com/edx/ux-pattern-library
-    path_scss:              /ux-pattern-library/blob/master/_src/static/sass/
+    path_scss:              /blob/master/pattern-library/sass/
     docurl:                 https://github.com/edx/ux-pattern-library/wiki/
 
 

--- a/_layouts/element.html
+++ b/_layouts/element.html
@@ -81,7 +81,7 @@ viewclass:  element
                     <h2 class="pldoc-heading pldoc-tab-heading pldoc-element-style-title">{{page.title}} Style</h2>
 
                     <div class="pldoc-tab-content">
-                        <p class="copy copy-base">You can find <a class="pldoc-link" href="{{site.github.path_scss}}{{page.scssurl}}">the original source of the CSS as SCSS</a> in this project's repo.</p>
+                        <p class="copy copy-base">You can find <a class="pldoc-link" href="{{site.github.repo}}{{site.github.path_scss}}{{page.scssurl}}">the original source of the CSS as SCSS</a> in this project's repo.</p>
                     </div>
                 </div>
             </div>

--- a/_posts/elements/2015-03-25-headings.md
+++ b/_posts/elements/2015-03-25-headings.md
@@ -10,7 +10,7 @@ tags:
 - headings
 
 slug:         headings
-scssurl:      "https://github.com/edx/ux-pattern-library/blob/master/_src/pattern-library/sass/components/_headings.scss"
+scssurl:      "components/_headings.scss"
 
 
 

--- a/_posts/elements/2015-04-09-buttons.md
+++ b/_posts/elements/2015-04-09-buttons.md
@@ -10,7 +10,7 @@ tags:
 - buttons
 
 slug:         buttons
-scssurl:      "https://github.com/edx/ux-pattern-library/blob/master/_src/pattern-library/sass/components/_buttons.scss"
+scssurl:      "components/_buttons.scss"
 
 description:  A collection of buttons available for using within the edX platform.
 

--- a/_posts/elements/2015-04-27-copy.md
+++ b/_posts/elements/2015-04-27-copy.md
@@ -10,7 +10,7 @@ tags:
 - copy
 
 slug:         copy
-scssurl:      "https://github.com/edx/ux-pattern-library/blob/master/_src/pattern-library/sass/components/_copy.scss"
+scssurl:      "components/_copy.scss"
 
 description:  Examples of copy in a semi-real world context.
 

--- a/_posts/elements/2015-05-12-forms.md
+++ b/_posts/elements/2015-05-12-forms.md
@@ -10,7 +10,7 @@ tags:
 - forms
 
 slug:         forms
-scssurl:      "https://github.com/edx/ux-pattern-library/blob/master/_src/edx-pl/sass/components/_forms.scss"
+scssurl:      "components/_forms.scss"
 
 doc: Styleguide:-Forms
 

--- a/_posts/elements/2015-07-01-grid.md
+++ b/_posts/elements/2015-07-01-grid.md
@@ -10,7 +10,7 @@ tags:
 - grid
 
 slug:       grid
-scssurl:    "https://github.com/edx/ux-pattern-library/blob/master/_src/pattern-library/sass/components/_grid.scss"
+scssurl:    "components/_grid.scss"
 
 example:    grid.html
 doc:        Styleguide:-Grid-System

--- a/_posts/elements/2015-07-10-layouts.md
+++ b/_posts/elements/2015-07-10-layouts.md
@@ -10,7 +10,7 @@ tags:
 - layouts
 
 slug:         layouts
-scssurl:      "https://github.com/edx/ux-pattern-library/blob/master/_src/pattern-library/sass/components/_layouts.scss"
+scssurl:      "components/_layouts.scss"
 
 description:  Preset view-based and section-based layouts.
 

--- a/_posts/elements/2015-07-21-depth.md
+++ b/_posts/elements/2015-07-21-depth.md
@@ -10,7 +10,7 @@ tags:
 - depth
 
 slug:         depth
-scssurl:      "https://github.com/edx/ux-pattern-library/blob/master/_src/pattern-library/sass/components/_depth.scss"
+scssurl:      "components/_depth.scss"
 
 description:  Visual depth system that be used throughout a UI.
 

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ viewclass:  index
                         <h2 class="pldoc-heading pldoc-tab-heading pldoc-element-styling-title">{{post.title}} Style</h2>
 
                         <div class="pldoc-tab-content">
-                            <p class="copy copy-base">View <a class="pldoc-link" href="{{post.scssurl}}">the original source of the CSS as SCSS</a> in this project's repo.</p>
+                            <p class="copy copy-base">View <a class="pldoc-link" href="{{site.github.repo}}{{site.github.path_scss}}{{post.scssurl}}">the original source of the CSS as SCSS</a> in this project's repo.</p>
                         </div>
                     </div>
                     {% endif %}


### PR DESCRIPTION
This work fixes and abstracts even more scss link paths per element in the documentation site. This got out of whack with the recent directory changes needed to make the pattern library a versioned Bower Package.

 - - -

##### Reviewers

* [x] FED/Doc Site MGMT - @frrrances 