### PR TITLE
PL Doc: Add in Additional Asset Tasks to Gulp Workflow

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -51,13 +51,13 @@ module.exports = {
     images:                     {
         // pattern library
         src:                    './pattern-library/images',
-        src_files:              './pattern-library/images/**',
+        src_files:              './pattern-library/images/**/*',
         dest:                   './public/images',
         local:                  './_site/public/images',
 
         // documentation site
         pldoc_src:              './pldoc/static/images',
-        pldoc_src_files:        './pldoc/static/images/**'
+        pldoc_src_files:        './pldoc/static/images/**/*'
     },
     icons:                     {
         // pattern library

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -48,6 +48,17 @@ module.exports = {
         pldoc_src:              './pldoc/static/images',
         pldoc_src_files:        './pldoc/static/images/**'
     },
+    icons:                     {
+        // pattern library
+        src:                    src + '/icons',
+        src_files:              src + '/icons/**/*',
+        dest:                   dest + '/icons',
+        local:                  local + '/public/icons',
+
+        // documentation site
+        pldoc_src:              pldoc_src + '/static/icons',
+        pldoc_src_files:        pldoc_src + '/static/icons/**/*'
+    },
     scripts:                    {
         // pattern library
         src:                    src + '/js',

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -37,6 +37,17 @@ module.exports = {
         pldoc_src:              pldoc_src + '/static/sass',
         pldoc_src_files:        pldoc_src + '/static/sass/**/*.scss'
     },
+    fonts:                     {
+        // pattern library
+        src:                    src + '/fonts',
+        src_files:              src + '/fonts/**/*',
+        dest:                   dest + '/fonts',
+        local:                  local + '/public/fonts',
+
+        // documentation site
+        pldoc_src:              pldoc_src + '/static/fonts',
+        pldoc_src_files:        pldoc_src + '/static/fonts/**/*'
+    },
     images:                     {
         // pattern library
         src:                    './pattern-library/images',

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -6,6 +6,7 @@ gulp.task( 'clean', function() {
     return del([
         config.scripts.dest,
         config.images.dest,
+        config.icons.dest,
         config.styles.dest
     ]);
 });

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -7,6 +7,7 @@ gulp.task( 'clean', function() {
         config.scripts.dest,
         config.images.dest,
         config.icons.dest,
+        config.fonts.dest,
         config.styles.dest
     ]);
 });

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -4,6 +4,7 @@ var gulp            = require('gulp'),
 gulp.task( 'default', function() {
     runSequence(
         'clean',
+        ['icons'],
         ['images'],
         ['scripts','pldoc_scripts'],
         'styles',

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -5,6 +5,7 @@ gulp.task( 'default', function() {
     runSequence(
         'clean',
         ['icons'],
+        ['fonts'],
         ['images'],
         ['scripts','pldoc_scripts'],
         'styles',

--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -1,0 +1,17 @@
+var gulp            = require('gulp'),
+    browserSync     = require('browser-sync'),
+    changed         = require('gulp-changed'),
+    config          = require('../config').fonts,
+    merge           = require('merge-stream');
+
+gulp.task('fonts', function() {
+
+    var fonts = gulp.src(config.src_files);
+    var pldoc_fonts = gulp.src(config.pldoc_src_files);
+
+    return merge(fonts, pldoc_fonts)
+        .pipe(changed(config.dest)) // ignore unchanged files
+        .pipe(gulp.dest(config.local)) // move just for browersync + uncompressed local
+        .pipe(browserSync.reload({stream:true}))
+        .pipe(gulp.dest(config.dest))
+});

--- a/gulp/tasks/icons.js
+++ b/gulp/tasks/icons.js
@@ -1,0 +1,17 @@
+var gulp            = require('gulp'),
+    browserSync     = require('browser-sync'),
+    changed         = require('gulp-changed'),
+    config          = require('../config').icons,
+    merge           = require('merge-stream');
+
+gulp.task('icons', function() {
+
+    var icons = gulp.src(config.src_files);
+    var pldoc_icons = gulp.src(config.pldoc_src_files);
+
+    return merge(icons, pldoc_icons)
+        .pipe(changed(config.dest)) // ignore unchanged files
+        .pipe(gulp.dest(config.local)) // move just for browersync + uncompressed local
+        .pipe(browserSync.reload({stream:true}))
+        .pipe(gulp.dest(config.dest))
+});


### PR DESCRIPTION
This work adds in quick support for moving both icons and fonts to the proper UXPL Documentation Site paths needed for both production and for local development.

**NOTE**: This work only moves assets using the default gulp task (running ``gulp``). It does not watch assets yet. A follow-on PR will tackle that.

- - -

#### Reviewers

* [ ] Directory structure/Gulp workflow - @clrux 