### PR TITLE
PL Doc: Abstract Production/Development Build-centric Gulp Tasks

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -22,11 +22,6 @@ module.exports = {
             sourcemapsLocation: '.'
         },
 
-        settings_production: {
-            outputStyle: 'compressed',
-            autoprefixer: { browsers: ['last 2 version'] }
-        },
-
         // pattern library
         src_files:              src + '/sass/**/*.scss',
         dest:                   dest + '/css',

--- a/gulp/tasks/build-development.js
+++ b/gulp/tasks/build-development.js
@@ -1,0 +1,12 @@
+var gulp = require('gulp'),
+    runSequence    = require('run-sequence');
+
+gulp.task( 'build-development', function(cb) {
+    runSequence(
+        'clean',
+        'fonts',
+        'images',
+        ['scripts','pldoc_scripts'],
+        'styles',
+    cb);
+});

--- a/gulp/tasks/build-production.js
+++ b/gulp/tasks/build-production.js
@@ -1,0 +1,10 @@
+var gulp = require('gulp'),
+    runSequence    = require('run-sequence');
+
+gulp.task( 'build-production', function(cb) {
+    runSequence(
+        'build-development',
+        'scripts-uglify',
+        'styles-minify',
+    cb);
+});

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,15 +1,11 @@
 var gulp            = require('gulp'),
-    runSequence    = require('run-sequence');
+    runSequence     = require('run-sequence');
 
-gulp.task( 'default', function() {
+gulp.task( 'default', function(cb) {
     runSequence(
-        'clean',
-        ['fonts'],
-        ['images'],
-        ['scripts','pldoc_scripts'],
-        'styles',
-        'watch'
-    )
+        'build-development',
+        'watch',
+    cb);
 });
 
 

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,21 +1,17 @@
 var gulp            = require('gulp'),
     autoprefixer    = require('gulp-autoprefixer'),
     browserSync     = require('browser-sync'),
-    changed         = require('gulp-changed'),
     config          = require('../config').styles,
     handleErrors    = require('../util/handleErrors'),
-    minifyCSS       = require('gulp-minify-css'),
     sass            = require('gulp-sass'),
     sourcemaps      = require('gulp-sourcemaps');
 
 gulp.task('styles', function () {
     return gulp.src(config.pldoc_src_files)
         .pipe(sourcemaps.init())
-        .pipe(changed(config.dest)) // ignore unchanged files
         .pipe(sass(config.settings_develepment))
         .on('error', handleErrors)
         .pipe(autoprefixer())
-        .pipe(minifyCSS())
         .pipe(sourcemaps.write(config.settings_development.sourcemapsLocation))
         .pipe(gulp.dest(config.local)) // move just for browersync + uncompressed local
         .pipe(browserSync.reload({stream:true}))


### PR DESCRIPTION
This work takes the good recommendation @frrrances had, and the practice that I've personally set up at https://github.com/talbs/mise-en-place/tree/master/gulp/tasks, and creates ``build-production`` and ``build-development`` Gulp tasks. the ``default`` task has been simplified and now uses the ``build-development`` task.

Additionally, the ``styles`` task and config settings have been revised to:

* not contain any production-centric steps (minifying CSS now happens within ``build-production``, which should be run before committing any compiled assets.)
* remove any production-centric settings that were not being used by the new tasks.

- - -

##### Reviwers

* [x] @frrrances - Gulp logic/abstraction & task use
* [ ] @AlasdairSwan - Gulp/CSS workflow