### PR TITLE
PL Doc: Set where Bower packages are installed

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "./bower_components/",
+  "analytics": false
+}


### PR DESCRIPTION
This work adds a .bowerrc file to firm up location of installed packages to help override any local dev global settings when individuals are running the PL Doc Site locally.

- - -

##### Reviewers

* [x] @dsjen 