### PR TITLE
Adding text truncation and wrapped Sass placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Nothing yet
 
 - - -
 
+## 0.4.3 (2015-10-28)
+* Added text truncation and wrapped Sass placeholders
+
+- - -
+
 ## 0.4.2 (2015-10-23)
 * Removed _colors.scss as a main pattern (since it was only providing supportive styling for the documentation site) and placed its rules within the documentation site's Sass.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],

--- a/pattern-library/sass/utilities/_helpers.scss
+++ b/pattern-library/sass/utilities/_helpers.scss
@@ -41,6 +41,17 @@
     }
 }
 
+%text-wrap {
+    @include word-wrap(break-word);
+    @include hyphens(auto);
+}
+
+%text-ellipsis {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
 // accessibility
 %a11y-hide {
     border: 0;


### PR DESCRIPTION
Per the fix noted in https://github.com/edx/edx-platform/pull/10405, this work proactively adds in some Sass placeholder utilities for use alongside the Pattern Library

- - -

##### Reviwers

* [ ] Sass - @frrrances 