### PR TITLE
Increase placeholder image sizes

### DIFF
--- a/_posts/patterns/2015-07-01-grid.md
+++ b/_posts/patterns/2015-07-01-grid.md
@@ -485,94 +485,94 @@ info:               A responsive, mobile first fluid grid system, based on Susy 
     <div class="example-grid example-grid-gallery-semantic">
         <section class="photo-gallery photo-gallery-large">
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/1000x500" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-meta">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/1000x500" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-meta">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/1000x500" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-meta">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/1000x500" alt="Puppies playing in a field">
                <figcaption class="photo-caption copy-meta">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/1000x500" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-meta">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/1000x500" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-meta">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
         </section>
 
         <section class="photo-gallery">
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
 
             <figure class="photo">
-                <img class="photo-source" src="http://placehold.it/200x100" alt="Puppies playing in a field">
+                <img class="photo-source" src="http://placehold.it/500x250" alt="Puppies playing in a field">
                 <figcaption class="photo-caption copy-micro">Wobbled this darn and warthog compatibly that smoothly tediously ashamed while grouped around tangibly inanimately unkindly wailed awkward</figcaption>
             </figure>
         </section>


### PR DESCRIPTION
Drive-by contribution. I noticed the current placeholder images don't look so hot on high-resolution displays. This PR includes a commit bumping the sizes of the placeholder images. For example, here's before:

![](http://i.imgur.com/vUpV7pZ.png)

And here's after:
![](http://i.imgur.com/kgbQ7th.png)

@talbs, impressions? How do you deploy to http://ux.edx.org/?