### PR TITLE
FIX - Using an Example of a Link as a Button

### DIFF
--- a/_posts/patterns/2015-04-09-buttons.md
+++ b/_posts/patterns/2015-04-09-buttons.md
@@ -11,11 +11,12 @@ tags:
 
 slug:           buttons
 
-url_styles:     "components/_buttons.scss"
+url_styles:     "patterns/_buttons.scss"
+url_documentation:  Styleguide:-Accessibility#buttons-and-links
 
 description:    A collection of buttons available for using within the edX platform.
 
-info:           Buttons should be used for performing actions within the edX environment. While we supply a button that looks like a link, it should only really be used for very tertiary actions. edX offers three button sizes, each with normal, hover, active/pressed, and disabled states. We also offer a range of other buttons to suit your needs.
+info:          Buttons should be used for performing actions within the edX environment.  While you may apply the visual style of these elements to both semantic links and buttons, a good rule of thumb is that buttons do something while links go somewhere. Buttons have several visual weights, sizes, and add-ons that can be configured alongside their use.
 ---
 
 <h3 class="hd-6 example-set-hd">Default</h3>


### PR DESCRIPTION
This work aims to adjust the instructions and information around the button pattern's visual styling to help users of the UXPL choose the appropriate semantic element/markup for their needs (regardless of styling).

- - -

##### Reviewers

* [ ] @cptvitamin 