### PR TITLE
Remove demo directory from the public packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ pldoc
 about.md
 bower_components
 CNAME
+demo
 examples
 favicon.ico
 gulp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Nothing yet
 
 - - -
 
+## 0.8.8 (2016-01-26)
+* Remove demo directory from the public packages.
+
+- - -
+
 ## 0.8.7 (2016-01-25)
 * Removed pointer from progress bar hover
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],
@@ -32,6 +32,7 @@
     "about.md",
     "bower_components",
     "CNAME",
+    "demo",
     "examples",
     "favicon.ico",
     "gulp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": "edX UX Team <ux@edx.org>",
   "license": "Apache-2.0",
   "description": "The (working) Visual, UI, and Front End Styleguide for edX Apps",


### PR DESCRIPTION
I've removed the demo directory from the npm and bower packages, and bumped the version number.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @dsjen 
- [x] Code review: @talbs 

### Post-review
- [ ] Squash commits