### PR TITLE
FIX - Removing Reference to Deleted Sass Extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## unreleased
 Nothing yet
 
+## 0.8.9 (2016-01-26)
+* removing reference to deleted %reset-copy utility
+
 - - -
 
 ## 0.8.8 (2016-01-26)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "author": "edX UX Team <ux@edx.org>",
   "license": "Apache-2.0",
   "description": "The (working) Visual, UI, and Front End Styleguide for edX Apps",

--- a/pattern-library/sass/global/_reset.scss
+++ b/pattern-library/sass/global/_reset.scss
@@ -161,10 +161,3 @@ h5 {
 h6 {
    font-size: font-size(small);
 }
-
-
-// copy
-.copy,
-p, ol, ul, dl, td, th {
-    @extend %reset-copy;
-}


### PR DESCRIPTION
This work removes a reference to a deleted Sass extend that is no longer used, ``%reset-copy``.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @dsjen 

### Post-review
- [ ] Squash commits
- [ ] Publish packages/doc site