### PR TITLE
FIX - Removing Unused Extend from Buttons Sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Nothing yet
 
 - - -
 
+## 0.8.11 (2016-01-26)
+* Removed unused %btn-base extend from buttons
+
+- - -
+
 ## 0.8.10 (2016-01-26)
 * Remove unused .list-links/%list-links rules.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": "edX UX Team <ux@edx.org>",
   "license": "Apache-2.0",
   "description": "The (working) Visual, UI, and Front End Styleguide for edX Apps",

--- a/pattern-library/sass/patterns/_buttons.scss
+++ b/pattern-library/sass/patterns/_buttons.scss
@@ -113,7 +113,6 @@ $btn-inverse-disabled-focus-background:     $transparent !default;
         background timing(xx-fast) ease-in-out 0s,
         box-shadow timing(xx-fast) ease-in-out 0s
     );
-    @extend %btn-base;
     display: inline-block;
     border-style: $btn-border-style;
     border-radius: $btn-border-radius;


### PR DESCRIPTION
This work removes the unused ``%btn-base`` extend from buttons Sass.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @dsjen 

### Post-review
- [x] Squash commits
- [ ] Publish packages/doc site