### PR TITLE
FIX - Remove Unused "list-links" Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## unreleased
 Nothing yet
 
+- - -
+
+## 0.8.10 (2016-01-26)
+* Remove unused .list-links/%list-links rules.
+
+- - -
+
 ## 0.8.9 (2016-01-26)
 * removing reference to deleted %reset-copy utility
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "author": "edX UX Team <ux@edx.org>",
   "license": "Apache-2.0",
   "description": "The (working) Visual, UI, and Front End Styleguide for edX Apps",

--- a/pattern-library/sass/patterns/_lists.scss
+++ b/pattern-library/sass/patterns/_lists.scss
@@ -349,10 +349,6 @@ dd,
     @extend %list-inline;
 }
 
-.list-links {
-    @extend %list-links;
-}
-
 .list-grouped {
     @extend %list-grouped;
 }


### PR DESCRIPTION
This work removes the unused ``.list-links``/``%list-links`` extend from buttons Sass.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @dsjen 

### Post-review
- [x] Squash commits
- [ ] Publish packages/doc site