### PR TITLE
FIX - Publishing Missing Buttons Sass Extend Solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Nothing yet
 
 - - -
 
+## 0.8.12 (2016-01-26)
+* FIX- Removed unused %btn-base extend from buttons
+
+- - -
+
 ## 0.8.11 (2016-01-26)
 * Removed unused %btn-base extend from buttons
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": "edX UX Team <ux@edx.org>",
   "license": "Apache-2.0",
   "description": "The (working) Visual, UI, and Front End Styleguide for edX Apps",

--- a/pattern-library/sass/patterns/_buttons.scss
+++ b/pattern-library/sass/patterns/_buttons.scss
@@ -167,7 +167,6 @@ $btn-inverse-disabled-focus-background:     $transparent !default;
 // ----------------------------
 %btn-default {
     @extend %btn;
-    @extend %btn-base;
     border-color: $btn-default-border-color;
     background: $btn-default-background;
     color: $btn-default-color;


### PR DESCRIPTION
This fix publishes some missing code that was meant to be published with https://github.com/edx/ux-pattern-library/pull/273. For some reason this code change was not picked up in our ``0.8.11`` package version.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @andy-armstrong 

### Post-review
- [x] Squash commits
- [ ] Publish packages/doc site