### PR TITLE
Fix path loading issues when consuming the Pattern Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Nothing yet
 
 - - -
 
+## 0.9.1 (2016-02-01)
+* introduce $pattern-library-path variable
+* FIX - always refer to edx-icons via $edx-icons-font-path
+
+- - -
+
 ## 0.9 (2016-02-01)
 * adding tables pattern - for use in content and sortable table listings
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.9",
+  "version": "0.9.1",
   "authors": [
     "edX UX Team <ux@edx.org>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.9",
+  "version": "0.9.1",
   "author": "edX UX Team <ux@edx.org>",
   "license": "Apache-2.0",
   "description": "The (working) Visual, UI, and Front End Styleguide for edX Apps",

--- a/pattern-library/sass/global/_settings.scss
+++ b/pattern-library/sass/global/_settings.scss
@@ -17,9 +17,9 @@
 // ----------------------------
 // #PATHS
 // ----------------------------
-$font-path: '../fonts' !default;
-$image-path: '../images' !default;
-
+$pattern-library-path: '..' !default;
+$font-path: '#{$pattern-library-path}/fonts' !default;
+$image-path: '#{$pattern-library-path}/images' !default;
 
 // ----------------------------
 // #UNITS

--- a/pattern-library/sass/patterns/_icons.scss
+++ b/pattern-library/sass/patterns/_icons.scss
@@ -494,6 +494,6 @@ cc;
 
 @each $edx-icon in $edx-icons {
     .icon-fallback-img .icon-#{$edx-icon} {
-    background: url('../fonts/edx-icons/fallback-img/#{$edx-icon}.svg') center center no-repeat;
+    background: url('#{$edx-icons-font-path}/fallback-img/#{$edx-icon}.svg') center center no-repeat;
   }
 }


### PR DESCRIPTION
I've fixed a couple of issues that are blocking the usage of the Pattern Library in edx-platform:
1. I've introduced a new variable $edx-pattern-library-path that points to the root of the pattern library's assets. This allows a consuming library to override just this one variable and then have fonts, images etc be served from the correct location.
2. I fixed one instance where an edx-icons font was not referenced via $edx-icons-font-path.

These changes are needed to support https://github.com/edx/edx-platform/pull/11268.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @talbs 
- [ ] Code review: @dsjen 

### Post-review
- [ ] Squash commits
- [ ] Publish packages/doc site