### PR TITLE
Add a GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## Description
+
+TODO: Link to a JIRA ticket if one has been created for this feature/issue.
+Use the following format for a link: `[FEDX-100](https://openedx.atlassian.net/browse/FEDX-100)`
+
+TODO: Include a detailed description of the changes in the body of the PR.
+
+TODO: Build a preview version of the documentation using ``gulp preview`` and add the generated link here.
+  
+## Manual Test Plan
+
+TODO: If your changes require manual tests, include instructions for any required manual tests,
+and any manual testing that has already been performed.
+
+## Testing Checklist
+- [ ] Manually test responsive behavior.
+- [ ] Manually test right-to-left behavior.
+- [ ] Manually test a11y support.
+
+## Non-testing Checklist
+- [ ] Consider any documentation your change might need, and which users will be affected by this change.
+
+## Post-review
+- [ ] Squash commits into discrete sets of changes with descriptive commit messages.
+
+## Reviewers
+TODO: In this section, tag specific reviewers you know will want to have a look at this PR. Please
+leave this section blank if you do not know who to tag, and we will automatically suggest reviewers
+based on the code it touches.
+
+TODO: You can use the checklist below for organization:
+
+- [ ] @mention a reviewer here
+- [ ] @mention a reviewer here
+
+TODO: Consider not just code reviewers but also including reviewers from Docs, UX, Accessibility and Product, if applicable.
+
+If you've been tagged for review, please check your corresponding box once you've given the :+1:.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# How to contribute
+
+This is an Open edX repo, and we welcome your contributions!
+Please read the [contributing guidelines](http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html).
+
+Here are some areas of heightened importance to consider when contributing to the UI Toolkit:
+
+- RTL
+  - Will the feature work for right-to-left languages?
+- a11y
+  - Does markup make use of aria attributes, where applicable?
+- Browser support
+  - Does the feature work at all screen sizes and pixel densities?
+  - Are the browser features this code relies on available in all edX supported browsers?


### PR DESCRIPTION
I've created a GitHub pull request template that will be automatically added to all PRs created going forward. For the content, I merged our recommend pull request template with the new standard one that Cale merged today:

https://github.com/edx/cookiecutter-django-ida/pull/21/files

FYI, you can read more about the GitHub functionality here:

https://github.com/blog/2111-issue-and-pull-request-templates

@AlasdairSwan @dsjen @dan-f Please review.

- [x] @bjacobel