### PR TITLE
Clean up library import logic

### DIFF
--- a/_posts/patterns/2016-01-28-alerts.md
+++ b/_posts/patterns/2016-01-28-alerts.md
@@ -1,7 +1,7 @@
 ---
 layout:         pattern
 title:          Alerts
-date:           2015-01-28 00:00:00
+date:           2016-01-28 00:00:00
 
 categories:     patterns
 tags:

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -22,7 +22,10 @@ module.exports = {
 
         settings_development: {
             outputStyle: 'expanded',
-            sourcemapsLocation: '.'
+            sourcemapsLocation: '.',
+            includePaths: [
+                'node_modules'
+            ]
         },
 
         // pattern library

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,18 +1,23 @@
-var gulp            = require('gulp'),
-    autoprefixer    = require('gulp-autoprefixer'),
-    browserSync     = require('browser-sync'),
-    config          = require('../config').styles,
-    handleErrors    = require('../util/handleErrors'),
-    sass            = require('gulp-sass'),
-    sourcemaps      = require('gulp-sourcemaps');
+(function() {
+    'use strict';
 
-gulp.task('styles', function () {
-    return gulp.src(config.src_files)
-        .pipe(sourcemaps.init())
-        .pipe(sass(config.settings_develepment))
-        .on('error', handleErrors)
-        .pipe(autoprefixer())
-        .pipe(sourcemaps.write(config.settings_development.sourcemapsLocation))
-        .pipe(gulp.dest(config.dest))
-        .pipe(browserSync.reload({stream:true}));
-});
+    var gulp            = require('gulp'),
+        autoprefixer    = require('gulp-autoprefixer'),
+        browserSync     = require('browser-sync'),
+        config          = require('../config').styles,
+        handleErrors    = require('../util/handleErrors'),
+        sass            = require('gulp-sass'),
+        sourcemaps      = require('gulp-sourcemaps');
+
+    gulp.task('styles', function() {
+        return gulp.src(config.src_files)
+            .pipe(sourcemaps.init())
+            .pipe(sass(config.settings_development))
+            .on('error', handleErrors)
+            .pipe(autoprefixer())
+            .pipe(sourcemaps.write(config.settings_development.sourcemapsLocation))
+            .pipe(gulp.dest(config.dest))
+            .pipe(browserSync.reload({stream: true}));
+    });
+})();
+

--- a/pattern-library/sass/edx-pattern-library-ltr.scss
+++ b/pattern-library/sass/edx-pattern-library-ltr.scss
@@ -3,16 +3,10 @@
 
 // About: Sass compile for the edX Pattern Library's static CSS, for use in left-to-right styling.
 
-// ------------------------------
-// #LIB
-// ------------------------------
-@import '../../node_modules/bourbon/app/assets/stylesheets/bourbon';
-@import '../../node_modules/susy/sass/susy';
-@import '../../node_modules/breakpoint-sass/stylesheets/breakpoint';
-
 
 // ------------------------------
 // #BUILD
 // ------------------------------
-@import 'global/ltr';                                      // LTR-specifc settings and utilities
-@import 'edx-pattern-library';                      // shared compile/build order for both LTR and RTL UI
+@import 'global/lib';                    // third-party libraries
+@import 'global/ltr';                    // LTR-specifc settings and utilities
+@import 'edx-pattern-library';           // shared compile/build order for both LTR and RTL UI

--- a/pattern-library/sass/edx-pattern-library-rtl.scss
+++ b/pattern-library/sass/edx-pattern-library-rtl.scss
@@ -5,15 +5,8 @@
 
 
 // ------------------------------
-// #LIB
-// ------------------------------
-@import '../../node_modules/bourbon/app/assets/stylesheets/bourbon';
-@import '../../node_modules/susy/sass/susy';
-@import '../../node_modules/breakpoint-sass/stylesheets/breakpoint';
-
-
-// ------------------------------
 // #BUILD
 // ------------------------------
-@import 'global/rtl';                                      // LTR-specifc settings and utilities
-@import 'edx-pattern-library';                   // shared compile/build order for both LTR and RTL UI
+@import 'global/lib';                    // third-party libraries
+@import 'global/rtl';                    // LTR-specifc settings and utilities
+@import 'edx-pattern-library';           // shared compile/build order for both LTR and RTL UI

--- a/pattern-library/sass/global/_lib.scss
+++ b/pattern-library/sass/global/_lib.scss
@@ -1,0 +1,8 @@
+// ------------------------------
+// edX Pattern Library: Third Party Libraries
+
+// About: third party libraries and dependencies import
+
+@import 'bourbon/app/assets/stylesheets/bourbon';
+@import 'susy/sass/susy';
+@import 'breakpoint-sass/stylesheets/breakpoint';

--- a/pattern-library/sass/global/_ltr.scss
+++ b/pattern-library/sass/global/_ltr.scss
@@ -16,4 +16,4 @@ $layout-direction: ltr;
 // ----------------------------
 // #LIB
 // ----------------------------
-@import '../../node_modules/bi-app-sass/bi-app/bi-app-ltr';
+@import 'bi-app-sass/bi-app/bi-app-ltr';

--- a/pattern-library/sass/global/_rtl.scss
+++ b/pattern-library/sass/global/_rtl.scss
@@ -16,4 +16,4 @@ $layout-direction: rtl;
 // ----------------------------
 // #LIB
 // ----------------------------
-@import '../../node_modules/bi-app-sass/bi-app/bi-app-rtl';
+@import 'bi-app-sass/bi-app/bi-app-rtl';


### PR DESCRIPTION
Clean up the way that library imports are handled, to make it easier on consumers. Now the assumption is that the Pattern Library's node_modules directory will be added to the Sass load path, which means that references can be relative and can work in any client.

@AlasdairSwan @bjacobel @dan-f please review.