### PR TITLE
Updating UXPL icons to not use AFG

### DIFF
--- a/_posts/patterns/2015-04-15-icons.md
+++ b/_posts/patterns/2015-04-15-icons.md
@@ -37,25 +37,15 @@ info:               Icons are used to clearly and visually represent some inform
 
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-error" aria-hidden="true"></span>
-                <span class="text">Error</span>
-            </span>
-        </div>
-        <div class="use-description">
-            <p>Icon with text fallback</p>
+            <span class="icon icon-error" aria-hidden="true"></span>
+            <span class="sr-only">Error</span>
         </div>
     </div>
 
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-img">
-                <span class="icon icon-warning" aria-hidden="true"></span>
-                <span class="text">Warning</span>
-            </span>
-        </div>
-        <div class="use-description">
-            <p>Icon with image fallback</p>
+            <span class="icon icon-warning" aria-hidden="true"></span>
+            <span class="sr-only">Warning</span>
         </div>
     </div>
 </div>
@@ -65,10 +55,8 @@ info:               Icons are used to clearly and visually represent some inform
 <div class="example-set">
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-video-camera" aria-hidden="true"></span>
-                <span class="text">Video</span>
-            </span>
+            <span class="icon icon-video-camera" aria-hidden="true"></span>
+            <span class="sr-only">Video</span>
         </div>
         <div class="icon-classname">
             video-camera
@@ -76,10 +64,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-camera" aria-hidden="true"></span>
-                <span class="text">Camera</span>
-            </span>
+            <span class="icon icon-camera" aria-hidden="true"></span>
+            <span class="sr-only">Camera</span>
         </div>
         <div class="icon-classname">
             camera
@@ -87,10 +73,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-closed-captions" aria-hidden="true"></span>
-                <span class="text">Closed Captions</span>
-            </span>
+            <span class="icon icon-closed-captions" aria-hidden="true"></span>
+            <span class="sr-only">Closed Captions</span>
         </div>
         <div class="icon-classname">
             closed-captions
@@ -98,10 +82,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-pause" aria-hidden="true"></span>
-                <span class="text">Pause</span>
-            </span>
+            <span class="icon icon-pause" aria-hidden="true"></span>
+            <span class="sr-only">Pause</span>
         </div>
         <div class="icon-classname">
             pause
@@ -109,10 +91,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-play" aria-hidden="true"></span>
-                <span class="text">Play</span>
-            </span>
+            <span class="icon icon-play" aria-hidden="true"></span>
+            <span class="sr-only">Play</span>
         </div>
         <div class="icon-classname">
             play
@@ -120,10 +100,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-stop" aria-hidden="true"></span>
-                <span class="text">Stop</span>
-            </span>
+            <span class="icon icon-stop" aria-hidden="true"></span>
+            <span class="sr-only">Stop</span>
         </div>
         <div class="icon-classname">
             stop
@@ -131,10 +109,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-fullscreen" aria-hidden="true"></span>
-                <span class="text">Enter fullscreen</span>
-            </span>
+            <span class="icon icon-fullscreen" aria-hidden="true"></span>
+            <span class="sr-only">Enter fullscreen</span>
         </div>
         <div class="icon-classname">
             fullscreen
@@ -142,10 +118,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-exit-fullscreen" aria-hidden="true"></span>
-                <span class="text">Exit fullscreen</span>
-            </span>
+            <span class="icon icon-exit-fullscreen" aria-hidden="true"></span>
+            <span class="sr-only">Exit fullscreen</span>
         </div>
         <div class="icon-classname">
             exit-fullscreen
@@ -153,10 +127,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-volume-off" aria-hidden="true"></span>
-                <span class="text">Muted</span>
-            </span>
+            <span class="icon icon-volume-off" aria-hidden="true"></span>
+            <span class="sr-only">Muted</span>
         </div>
         <div class="icon-classname">
             volume-off
@@ -164,10 +136,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-volume-down" aria-hidden="true"></span>
-                <span class="text">Low volume</span>
-            </span>
+            <span class="icon icon-volume-down" aria-hidden="true"></span>
+            <span class="sr-only">Low volume</span>
         </div>
         <div class="icon-classname">
             volume-down
@@ -175,10 +145,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-volume-up" aria-hidden="true"></span>
-                <span class="text">High volume</span>
-            </span>
+            <span class="icon icon-volume-up" aria-hidden="true"></span>
+            <span class="sr-only">High volume</span>
         </div>
         <div class="icon-classname">
             volume-up
@@ -191,10 +159,8 @@ info:               Icons are used to clearly and visually represent some inform
 <div class="example-set">
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-user" aria-hidden="true"></span>
-                <span class="text">User account</span>
-            </span>
+            <span class="icon icon-user" aria-hidden="true"></span>
+            <span class="sr-only">User account</span>
         </div>
         <div class="icon-classname">
             user
@@ -202,10 +168,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-calendar" aria-hidden="true"></span>
-                <span class="text">Calendar</span>
-            </span>
+            <span class="icon icon-calendar" aria-hidden="true"></span>
+            <span class="sr-only">Calendar</span>
         </div>
         <div class="icon-classname">
             calendar
@@ -218,10 +182,8 @@ info:               Icons are used to clearly and visually represent some inform
 <div class="example-set">
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-arrow-up" aria-hidden="true"></span>
-                <span class="text">Up arrow</span>
-            </span>
+            <span class="icon icon-arrow-up" aria-hidden="true"></span>
+            <span class="sr-only">Up arrow</span>
         </div>
         <div class="icon-classname">
             arrow-up
@@ -229,10 +191,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-arrow-down" aria-hidden="true"></span>
-                <span class="text">Down arrow</span>
-            </span>
+            <span class="icon icon-arrow-down" aria-hidden="true"></span>
+            <span class="sr-only">Down arrow</span>
         </div>
         <div class="icon-classname">
             arrow-down
@@ -240,10 +200,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-arrow-circle-down" aria-hidden="true"></span>
-                <span class="text">Down arrow</span>
-            </span>
+            <span class="icon icon-arrow-circle-down" aria-hidden="true"></span>
+            <span class="sr-only">Down arrow</span>
         </div>
         <div class="icon-classname">
             arrow-circle-down
@@ -251,10 +209,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-angle-left" aria-hidden="true"></span>
-                <span class="text">Left arrow</span>
-            </span>
+            <span class="icon icon-angle-left" aria-hidden="true"></span>
+            <span class="sr-only">Left arrow</span>
         </div>
         <div class="icon-classname">
             angle-left
@@ -262,10 +218,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-angle-right" aria-hidden="true"></span>
-                <span class="text">Right arrow</span>
-            </span>
+            <span class="icon icon-angle-right" aria-hidden="true"></span>
+            <span class="sr-only">Right arrow</span>
         </div>
         <div class="icon-classname">
             angle-right
@@ -273,10 +227,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-angle-up" aria-hidden="true"></span>
-                <span class="text">Up arrow</span>
-            </span>
+            <span class="icon icon-angle-up" aria-hidden="true"></span>
+            <span class="sr-only">Up arrow</span>
         </div>
         <div class="icon-classname">
             angle-up
@@ -284,10 +236,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-angle-down" aria-hidden="true"></span>
-                <span class="text">Down arrow</span>
-            </span>
+            <span class="icon icon-angle-down" aria-hidden="true"></span>
+            <span class="sr-only">Down arrow</span>
         </div>
         <div class="icon-classname">
             angle-down
@@ -295,10 +245,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-refresh" aria-hidden="true"></span>
-                <span class="text">Refresh</span>
-            </span>
+            <span class="icon icon-refresh" aria-hidden="true"></span>
+            <span class="sr-only">Refresh</span>
         </div>
         <div class="icon-classname">
             refresh
@@ -306,10 +254,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-menu" aria-hidden="true"></span>
-                <span class="text">Menu</span>
-            </span>
+            <span class="icon icon-menu" aria-hidden="true"></span>
+            <span class="sr-only">Menu</span>
         </div>
         <div class="icon-classname">
             menu, reorder, bars
@@ -317,10 +263,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-ellipsis" aria-hidden="true"></span>
-                <span class="text">Ellipsis</span>
-            </span>
+            <span class="icon icon-ellipsis" aria-hidden="true"></span>
+            <span class="sr-only">Ellipsis</span>
         </div>
         <div class="icon-classname">
             ellipsis
@@ -333,10 +277,8 @@ info:               Icons are used to clearly and visually represent some inform
 <div class="example-set">
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-trash" aria-hidden="true"></span>
-                <span class="text">Delete</span>
-            </span>
+            <span class="icon icon-trash" aria-hidden="true"></span>
+            <span class="sr-only">Delete</span>
         </div>
         <div class="icon-classname">
             trash, delete
@@ -344,10 +286,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-help" aria-hidden="true"></span>
-                <span class="text">Help</span>
-            </span>
+            <span class="icon icon-help" aria-hidden="true"></span>
+            <span class="sr-only">Help</span>
         </div>
         <div class="icon-classname">
             help
@@ -355,10 +295,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-check" aria-hidden="true"></span>
-                <span class="text">Check Mark</span>
-            </span>
+            <span class="icon icon-check" aria-hidden="true"></span>
+            <span class="sr-only">Check Mark</span>
         </div>
         <div class="icon-classname">
             check
@@ -366,10 +304,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-close" aria-hidden="true"></span>
-                <span class="text">Close</span>
-            </span>
+            <span class="icon icon-close" aria-hidden="true"></span>
+            <span class="sr-only">Close</span>
         </div>
         <div class="icon-classname">
             close, remove
@@ -377,10 +313,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-close-circle" aria-hidden="true"></span>
-                <span class="text">Remove</span>
-            </span>
+            <span class="icon icon-close-circle" aria-hidden="true"></span>
+            <span class="sr-only">Remove</span>
         </div>
         <div class="icon-classname">
             close-circle
@@ -388,10 +322,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-close-circle-light" aria-hidden="true"></span>
-                <span class="text">Remove</span>
-            </span>
+            <span class="icon icon-close-circle-light" aria-hidden="true"></span>
+            <span class="sr-only">Remove</span>
         </div>
         <div class="icon-classname">
             close-circle-light
@@ -399,10 +331,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-error" aria-hidden="true"></span>
-                <span class="text">Error</span>
-            </span>
+            <span class="icon icon-error" aria-hidden="true"></span>
+            <span class="sr-only">Error</span>
         </div>
         <div class="icon-classname">
             error
@@ -410,10 +340,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-warning" aria-hidden="true"></span>
-                <span class="text">Warning</span>
-            </span>
+            <span class="icon icon-warning" aria-hidden="true"></span>
+            <span class="sr-only">Warning</span>
         </div>
         <div class="icon-classname">
             warning
@@ -421,10 +349,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-information" aria-hidden="true"></span>
-                <span class="text">Information</span>
-            </span>
+            <span class="icon icon-information" aria-hidden="true"></span>
+            <span class="sr-only">Information</span>
         </div>
         <div class="icon-classname">
             information
@@ -437,10 +363,8 @@ info:               Icons are used to clearly and visually represent some inform
 <div class="example-set">
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-checkbox-checked" aria-hidden="true"></span>
-                <span class="text">Checked checkbox</span>
-            </span>
+            <span class="icon icon-checkbox-checked" aria-hidden="true"></span>
+            <span class="sr-only">Checked checkbox</span>
         </div>
         <div class="icon-classname">
             checkbox-checked
@@ -448,10 +372,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-checkbox-unchecked" aria-hidden="true"></span>
-                <span class="text">Unchecked checkbox</span>
-            </span>
+            <span class="icon icon-checkbox-unchecked" aria-hidden="true"></span>
+            <span class="sr-only">Unchecked checkbox</span>
         </div>
         <div class="icon-classname">
             checkbox-unchecked
@@ -459,10 +381,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-checkbox-checked-dark" aria-hidden="true"></span>
-                <span class="text">Checked checkbox</span>
-            </span>
+            <span class="icon icon-checkbox-checked-dark" aria-hidden="true"></span>
+            <span class="sr-only">Checked checkbox</span>
         </div>
         <div class="icon-classname">
             checkbox-checked-dark
@@ -470,10 +390,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-radio-unchecked" aria-hidden="true"></span>
-                <span class="text">Unchecked radio</span>
-            </span>
+            <span class="icon icon-radio-unchecked" aria-hidden="true"></span>
+            <span class="sr-only">Unchecked radio</span>
         </div>
         <div class="icon-classname">
             radio-unchecked
@@ -481,10 +399,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-radio-checked" aria-hidden="true"></span>
-                <span class="text">Checked radio</span>
-            </span>
+            <span class="icon icon-radio-checked" aria-hidden="true"></span>
+            <span class="sr-only">Checked radio</span>
         </div>
         <div class="icon-classname">
             radio-checked
@@ -497,10 +413,8 @@ info:               Icons are used to clearly and visually represent some inform
 <div class="example-set">
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-list" aria-hidden="true"></span>
-                <span class="text">Unordered list</span>
-            </span>
+            <span class="icon icon-list" aria-hidden="true"></span>
+            <span class="sr-only">Unordered list</span>
         </div>
         <div class="icon-classname">
             list
@@ -508,10 +422,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-list-alt" aria-hidden="true"></span>
-                <span class="text">List</span>
-            </span>
+            <span class="icon icon-list-alt" aria-hidden="true"></span>
+            <span class="sr-only">List</span>
         </div>
         <div class="icon-classname">
             list-alt
@@ -519,10 +431,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-clock" aria-hidden="true"></span>
-                <span class="text">Clock</span>
-            </span>
+            <span class="icon icon-clock" aria-hidden="true"></span>
+            <span class="sr-only">Clock</span>
         </div>
         <div class="icon-classname">
             clock
@@ -530,10 +440,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-filter" aria-hidden="true"></span>
-                <span class="text">Filter</span>
-            </span>
+            <span class="icon icon-filter" aria-hidden="true"></span>
+            <span class="sr-only">Filter</span>
         </div>
         <div class="icon-classname">
             filter
@@ -541,10 +449,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-sort" aria-hidden="true"></span>
-                <span class="text">Sort</span>
-            </span>
+            <span class="icon icon-sort" aria-hidden="true"></span>
+            <span class="sr-only">Sort</span>
         </div>
         <div class="icon-classname">
             sort, unsorted
@@ -552,10 +458,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-undo" aria-hidden="true"></span>
-                <span class="text">Undo</span>
-            </span>
+            <span class="icon icon-undo" aria-hidden="true"></span>
+            <span class="sr-only">Undo</span>
         </div>
         <div class="icon-classname">
             undo, rotate-left
@@ -563,10 +467,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-table" aria-hidden="true"></span>
-                <span class="text">Table</span>
-            </span>
+            <span class="icon icon-table" aria-hidden="true"></span>
+            <span class="sr-only">Table</span>
         </div>
         <div class="icon-classname">
             table
@@ -574,10 +476,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-book" aria-hidden="true"></span>
-                <span class="text">Bookmark</span>
-            </span>
+            <span class="icon icon-book" aria-hidden="true"></span>
+            <span class="sr-only">Bookmark</span>
         </div>
         <div class="icon-classname">
             book
@@ -585,10 +485,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-money" aria-hidden="true"></span>
-                <span class="text">Dollar bill</span>
-            </span>
+            <span class="icon icon-money" aria-hidden="true"></span>
+            <span class="sr-only">Dollar bill</span>
         </div>
         <div class="icon-classname">
             money
@@ -596,10 +494,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-file" aria-hidden="true"></span>
-                <span class="text">File</span>
-            </span>
+            <span class="icon icon-file" aria-hidden="true"></span>
+            <span class="sr-only">File</span>
         </div>
         <div class="icon-classname">
             file
@@ -607,10 +503,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-file-light" aria-hidden="true"></span>
-                <span class="text">File</span>
-            </span>
+            <span class="icon icon-file-light" aria-hidden="true"></span>
+            <span class="sr-only">File</span>
         </div>
         <div class="icon-classname">
             file-light
@@ -618,10 +512,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-home" aria-hidden="true"></span>
-                <span class="text">Home</span>
-            </span>
+            <span class="icon icon-home" aria-hidden="true"></span>
+            <span class="sr-only">Home</span>
         </div>
         <div class="icon-classname">
             home
@@ -629,10 +521,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-external-link" aria-hidden="true"></span>
-                <span class="text">External link</span>
-            </span>
+            <span class="icon icon-external-link" aria-hidden="true"></span>
+            <span class="sr-only">External link</span>
         </div>
         <div class="icon-classname">
             external-link
@@ -640,10 +530,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-sitemap" aria-hidden="true"></span>
-                <span class="text">Sitemap</span>
-            </span>
+            <span class="icon icon-sitemap" aria-hidden="true"></span>
+            <span class="sr-only">Sitemap</span>
         </div>
         <div class="icon-classname">
            sitemap
@@ -651,10 +539,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-lock" aria-hidden="true"></span>
-                <span class="text">Locked</span>
-            </span>
+            <span class="icon icon-lock" aria-hidden="true"></span>
+            <span class="sr-only">Locked</span>
         </div>
         <div class="icon-classname">
             lock
@@ -662,10 +548,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-unlock" aria-hidden="true"></span>
-                <span class="text">Unlocked</span>
-            </span>
+            <span class="icon icon-unlock" aria-hidden="true"></span>
+            <span class="sr-only">Unlocked</span>
         </div>
         <div class="icon-classname">
             unlock
@@ -673,10 +557,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-search" aria-hidden="true"></span>
-                <span class="text">Search</span>
-            </span>
+            <span class="icon icon-search" aria-hidden="true"></span>
+            <span class="sr-only">Search</span>
         </div>
         <div class="icon-classname">
             search
@@ -684,10 +566,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-search-plus" aria-hidden="true"></span>
-                <span class="text">Zoom in</span>
-            </span>
+            <span class="icon icon-search-plus" aria-hidden="true"></span>
+            <span class="sr-only">Zoom in</span>
         </div>
         <div class="icon-classname">
             search-plus
@@ -695,10 +575,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-search-minus" aria-hidden="true"></span>
-                <span class="text">Zoom out</span>
-            </span>
+            <span class="icon icon-search-minus" aria-hidden="true"></span>
+            <span class="sr-only">Zoom out</span>
         </div>
         <div class="icon-classname">
             search-minus
@@ -706,10 +584,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-settings" aria-hidden="true"></span>
-                <span class="text">Settings</span>
-            </span>
+            <span class="icon icon-settings" aria-hidden="true"></span>
+            <span class="sr-only">Settings</span>
         </div>
         <div class="icon-classname">
             settings, cog, gear
@@ -717,10 +593,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-shopping-cart" aria-hidden="true"></span>
-                <span class="text">Checkout</span>
-            </span>
+            <span class="icon icon-shopping-cart" aria-hidden="true"></span>
+            <span class="sr-only">Checkout</span>
         </div>
         <div class="icon-classname">
             shopping-cart
@@ -728,10 +602,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-comments" aria-hidden="true"></span>
-                <span class="text">Comments</span>
-            </span>
+            <span class="icon icon-comments" aria-hidden="true"></span>
+            <span class="sr-only">Comments</span>
         </div>
         <div class="icon-classname">
             comments
@@ -739,10 +611,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-comment" aria-hidden="true"></span>
-                <span class="text">Comment</span>
-            </span>
+            <span class="icon icon-comment" aria-hidden="true"></span>
+            <span class="sr-only">Comment</span>
         </div>
         <div class="icon-classname">
             comment
@@ -750,10 +620,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-reply" aria-hidden="true"></span>
-                <span class="text">Reply</span>
-            </span>
+            <span class="icon icon-reply" aria-hidden="true"></span>
+            <span class="sr-only">Reply</span>
         </div>
         <div class="icon-classname">
             reply
@@ -761,10 +629,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-plus" aria-hidden="true"></span>
-                <span class="text">Add</span>
-            </span>
+            <span class="icon icon-plus" aria-hidden="true"></span>
+            <span class="sr-only">Add</span>
         </div>
         <div class="icon-classname">
             plus
@@ -772,10 +638,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-minus" aria-hidden="true"></span>
-                <span class="text">Remove</span>
-            </span>
+            <span class="icon icon-minus" aria-hidden="true"></span>
+            <span class="sr-only">Remove</span>
         </div>
         <div class="icon-classname">
             minus
@@ -783,10 +647,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-print" aria-hidden="true"></span>
-                <span class="text">Print</span>
-            </span>
+            <span class="icon icon-print" aria-hidden="true"></span>
+            <span class="sr-only">Print</span>
         </div>
         <div class="icon-classname">
             print
@@ -794,10 +656,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-pencil" aria-hidden="true"></span>
-                <span class="text">Pencil</span>
-            </span>
+            <span class="icon icon-pencil" aria-hidden="true"></span>
+            <span class="sr-only">Pencil</span>
         </div>
         <div class="icon-classname">
             pencil
@@ -805,10 +665,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-edit" aria-hidden="true"></span>
-                <span class="text">Edit</span>
-            </span>
+            <span class="icon icon-edit" aria-hidden="true"></span>
+            <span class="sr-only">Edit</span>
         </div>
         <div class="icon-classname">
             edit
@@ -816,10 +674,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-copy" aria-hidden="true"></span>
-                <span class="text">Copy</span>
-            </span>
+            <span class="icon icon-copy" aria-hidden="true"></span>
+            <span class="sr-only">Copy</span>
         </div>
         <div class="icon-classname">
             copy
@@ -827,10 +683,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-email" aria-hidden="true"></span>
-                <span class="text">Email</span>
-            </span>
+            <span class="icon icon-email" aria-hidden="true"></span>
+            <span class="sr-only">Email</span>
         </div>
         <div class="icon-classname">
             email
@@ -838,10 +692,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-flag" aria-hidden="true"></span>
-                <span class="text">Flag</span>
-            </span>
+            <span class="icon icon-flag" aria-hidden="true"></span>
+            <span class="sr-only">Flag</span>
         </div>
         <div class="icon-classname">
             flag
@@ -849,10 +701,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-thumb-tack" aria-hidden="true"></span>
-                <span class="text">Pin</span>
-            </span>
+            <span class="icon icon-thumb-tack" aria-hidden="true"></span>
+            <span class="sr-only">Pin</span>
         </div>
         <div class="icon-classname">
             thumb-tack
@@ -860,10 +710,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-link" aria-hidden="true"></span>
-                <span class="text">Link</span>
-            </span>
+            <span class="icon icon-link" aria-hidden="true"></span>
+            <span class="sr-only">Link</span>
         </div>
         <div class="icon-classname">
             link
@@ -871,10 +719,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-unlink" aria-hidden="true"></span>
-                <span class="text">Unlink</span>
-            </span>
+            <span class="icon icon-unlink" aria-hidden="true"></span>
+            <span class="sr-only">Unlink</span>
         </div>
         <div class="icon-classname">
             unlink
@@ -882,10 +728,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-quote-left" aria-hidden="true"></span>
-                <span class="text">Quote</span>
-            </span>
+            <span class="icon icon-quote-left" aria-hidden="true"></span>
+            <span class="sr-only">Quote</span>
         </div>
         <div class="icon-classname">
             quote-left
@@ -893,10 +737,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-upload" aria-hidden="true"></span>
-                <span class="text">Upload</span>
-            </span>
+            <span class="icon icon-upload" aria-hidden="true"></span>
+            <span class="sr-only">Upload</span>
         </div>
         <div class="icon-classname">
             upload
@@ -904,10 +746,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-show" aria-hidden="true"></span>
-                <span class="text">Show</span>
-            </span>
+            <span class="icon icon-show" aria-hidden="true"></span>
+            <span class="sr-only">Show</span>
         </div>
         <div class="icon-classname">
             show, visible
@@ -915,10 +755,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-hide" aria-hidden="true"></span>
-                <span class="text">Hide</span>
-            </span>
+            <span class="icon icon-hide" aria-hidden="true"></span>
+            <span class="sr-only">Hide</span>
         </div>
         <div class="icon-classname">
             hide, hidden
@@ -926,10 +764,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-share" aria-hidden="true"></span>
-                <span class="text">Share</span>
-            </span>
+            <span class="icon icon-share" aria-hidden="true"></span>
+            <span class="sr-only">Share</span>
         </div>
         <div class="icon-classname">
             share
@@ -937,10 +773,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-star" aria-hidden="true"></span>
-                <span class="text">Favorite</span>
-            </span>
+            <span class="icon icon-star" aria-hidden="true"></span>
+            <span class="sr-only">Favorite</span>
         </div>
         <div class="icon-classname">
             star
@@ -948,10 +782,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-bullhorn" aria-hidden="true"></span>
-                <span class="text">Notifications</span>
-            </span>
+            <span class="icon icon-bullhorn" aria-hidden="true"></span>
+            <span class="sr-only">Notifications</span>
         </div>
         <div class="icon-classname">
             bullhorn
@@ -959,10 +791,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-spinner" aria-hidden="true"></span>
-                <span class="text">Loading, please wait...</span>
-            </span>
+            <span class="icon icon-spinner" aria-hidden="true"></span>
+            <span class="sr-only">Loading, please wait...</span>
         </div>
         <div class="icon-classname">
             spinner
@@ -970,10 +800,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-twitter-square" aria-hidden="true"></span>
-                <span class="text">Twitter</span>
-            </span>
+            <span class="icon icon-twitter-square" aria-hidden="true"></span>
+            <span class="sr-only">Twitter</span>
         </div>
         <div class="icon-classname">
             twitter-square
@@ -981,10 +809,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-facebook-square" aria-hidden="true"></span>
-                <span class="text">Facebook</span>
-            </span>
+            <span class="icon icon-facebook-square" aria-hidden="true"></span>
+            <span class="sr-only">Facebook</span>
         </div>
         <div class="icon-classname">
             facebook-square
@@ -992,10 +818,8 @@ info:               Icons are used to clearly and visually represent some inform
     </div>
     <div class="example example-icon">
         <div class="icon-display">
-            <span class="icon-fallback icon-fallback-text">
-                <span class="icon icon-linkedin-square" aria-hidden="true"></span>
-                <span class="text">LinkedIn</span>
-            </span>
+            <span class="icon icon-linkedin-square" aria-hidden="true"></span>
+            <span class="sr-only">LinkedIn</span>
         </div>
         <div class="icon-classname">
             linkedin-square


### PR DESCRIPTION
## 1 of 4

This is part one of four that updates the UX Pattern Library to use the base icon font set, removing AFontGarde from the mix. Tests and conversation deemed AFontGarde unnecessary so this set of work aims to simply the library be removing unneeded dependencies and markup.

### Parts 2, 3, and 4

The other three parts can come at a later date, when other workloads calm down. They are as follows:

* remove the afontgarde use from the video player on edx-platform
* remove afontgarde from the pattern library
  * afontgarde.js
  * edx-icons.js
  * roll back Modernizr to the previous version
* remove afontgarde from edx-platform
  * package.json version bump to pick up the uxpl changes
  * removing edx-icons from the video player dependencies
  * remove edx-icons and afontgarde from require loaders

### Reviewers 

- [ ] @andy-armstrong 