### PR TITLE
Fix configuration typo in doc publishing

### DIFF
--- a/gulp/tasks/pldoc.js
+++ b/gulp/tasks/pldoc.js
@@ -55,6 +55,6 @@ gulp.task('webpack', function() {
 });
 
 gulp.task('doc-publish', ['jekyll-build'], function() {
-    return gulp.src(config.gitHubPages.files)
+    return gulp.src(config.documentation.gitHubPages.files)
         .pipe(ghPages());
 });


### PR DESCRIPTION
## Description

I fixed a bug when I tried using the new gulp task for publishing to GitHub Pages. I'd copied the task from the UI Toolkit, but the configuration is slightly different there.

I've verified the change by using the task to update [http://ux.edx.org/](http://ux.edx.org/)

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @bjacobel 
- [x] @AlasdairSwan 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

