### PR TITLE
Update $baseline to specify 'px'

### DIFF
--- a/pattern-library/sass/global/_settings.scss
+++ b/pattern-library/sass/global/_settings.scss
@@ -306,7 +306,7 @@ $z-depths: (
 // #SPACING
 // ----------------------------
 // spacing - baseline
-$baseline:                  20 !default;
+$baseline:                  20px !default;
 
 // vertical spacing
 $baseline-vertical:         ($baseline*2) !default;


### PR DESCRIPTION
## Description

Update ``$baseline`` to specify that its value is in pixels, primarily for compatibility with edx-platform. It also seems to make more sense to specify the unit (the baseline is 20 what?).
  
I manually verified that the Jekyll documentation still generates okay.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [ ] @AlasdairSwan 
- [ ] @dsjen

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

