### PR TITLE
Fix the patternLibraryPath in gulp tasks to point to the public folder

### DIFF
--- a/gulp/tasks/demo_styles.js
+++ b/gulp/tasks/demo_styles.js
@@ -10,7 +10,7 @@ gulp.task('demo-styles', function() {
         {
             source: config.documentation.rootDemoSassFile,
             targetDirectory: config.documentation.pldocDest,
-            patternLibraryPath: '/' + config.documentation.pldocDest + '/edx-pattern-library'
+            patternLibraryPath: '/public/edx-pattern-library'
         })
         .pipe(browserSync.stream());
 });

--- a/gulp/tasks/pldoc.js
+++ b/gulp/tasks/pldoc.js
@@ -44,7 +44,7 @@ gulp.task('pldoc-styles', function() {
         {
             source: config.documentation.rootSassFile,
             targetDirectory: config.documentation.pldocDest,
-            patternLibraryPath: '/' + config.documentation.pldocDest + '/edx-pattern-library'
+            patternLibraryPath: '/public/edx-pattern-library'
         }
     )
         .pipe(browserSync.stream());

--- a/gulp/tasks/preview.js
+++ b/gulp/tasks/preview.js
@@ -71,7 +71,7 @@ gulp.task('preview-styles', function() {
         {
             source: config.documentation.rootDemoSassFile,
             targetDirectory: config.documentation.pldocDest,
-            patternLibraryPath: '/' + branch + '/' + config.documentation.pldocDest + '/edx-pattern-library'
+            patternLibraryPath: '/' + branch + '/public/edx-pattern-library'
         }
     );
 });


### PR DESCRIPTION
## Description

Changes applied to demo, plod, and preview gulp styles tasks.