### PR TITLE
Add breadcrumbs pattern

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -19,7 +19,7 @@ gulp.task('watch', ['browserSync'], function() {
     gulp.watch(config.jekyll.posts, ['jekyll-rebuild']);
     gulp.watch(config.jekyll.components, ['jekyll-rebuild']);
     gulp.watch(config.jekyll.design_elements, ['jekyll-rebuild']);
-    gulp.watch(config.jekyll.includes, ['jekyll-rebuild']);
+    gulp.watch(config.jekyll.includes, ['pldoc-scripts', 'jekyll-rebuild']);
     gulp.watch(config.jekyll.examples, ['jekyll-rebuild']);
     gulp.watch(config.jekyll.demo, ['jekyll-rebuild']);
     gulp.watch(config.jekyll.layouts, ['jekyll-rebuild']);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browser-sync": "*",
     "css-loader": "~0.23.1",
     "del": "*",
-    "edx-ui-toolkit": "~0.10.0",
+    "edx-ui-toolkit": "file:../edx-ui-toolkit",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "0.8.5",
     "font-awesome-loader": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browser-sync": "*",
     "css-loader": "~0.23.1",
     "del": "*",
-    "edx-ui-toolkit": "file:../edx-ui-toolkit",
+    "edx-ui-toolkit": "~1.4.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "0.8.5",
     "font-awesome-loader": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browser-sync": "*",
     "css-loader": "~0.23.1",
     "del": "*",
-    "edx-ui-toolkit": "~1.4.0",
+    "edx-ui-toolkit": "~1.4.1",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "0.8.5",
     "font-awesome-loader": "0.0.1",

--- a/pattern-library/sass/_edx-pattern-library.scss
+++ b/pattern-library/sass/_edx-pattern-library.scss
@@ -24,3 +24,4 @@
 @import 'patterns/tables';
 @import 'patterns/alerts';
 @import 'patterns/dropdown-menu';
+@import 'patterns/breadcrumbs';

--- a/pattern-library/sass/patterns/_breadcrumbs.scss
+++ b/pattern-library/sass/patterns/_breadcrumbs.scss
@@ -4,12 +4,12 @@
     line-height: line-height(small);
 
     .nav-item {
-        @include margin-right($baseline/2);
+        @include margin-left($baseline/4);
         display: inline-block;
     }
 
     .fa.fa-angle-right {
-        @include margin-right($baseline/4);
+        @include margin-left($baseline/4);
         display: inline-block;
         color: palette(grayscale, light);
 

--- a/pattern-library/sass/patterns/_breadcrumbs.scss
+++ b/pattern-library/sass/patterns/_breadcrumbs.scss
@@ -8,7 +8,7 @@
         display: inline-block;
     }
 
-    .fa.fa-angle-right {
+    .fa-angle-right {
         @include margin-left($baseline/4);
         display: inline-block;
         color: palette(grayscale, light);

--- a/pattern-library/sass/patterns/_breadcrumbs.scss
+++ b/pattern-library/sass/patterns/_breadcrumbs.scss
@@ -1,0 +1,20 @@
+.breadcrumbs {
+    font-family: $font-family-sans-serif;
+    font-size: font-size(small);
+    line-height: line-height(small);
+
+    .nav-item {
+        @include margin-right($baseline/2);
+        display: inline-block;
+    }
+
+    .fa.fa-angle-right {
+        @include margin-right($baseline/4);
+        display: inline-block;
+        color: palette(grayscale, light);
+
+        @include rtl {
+            @include transform(rotateY(180deg));
+        }
+    }
+}

--- a/pldoc/_components/breadcrumbs.md
+++ b/pldoc/_components/breadcrumbs.md
@@ -23,14 +23,13 @@ js:                     "/examples/breadcrumbs-js.html"
 ---
 <div class="breadcrumbs-basic example-set">
   <h2>Basic breadcrumbs</h2>
-  <header class="has-breadcrumbs hd-3"></header>
+  <div class="has-breadcrumbs hd-3"></div>
   <a class="add-breadcrumb" href="">Add breadcrumb</a>
 </div>
 
 <div class="breadcrumbs-prerendered example-set">
   <h2>Pre-rendered breadcrumbs</h2>
-  <header class="has-breadcrumbs hd-3">
-    <div class="sr-is-focusable" tabindex="-1"></div>
+  <div class="has-breadcrumbs hd-3">
     <nav class="breadcrumbs list-inline" aria-label="Example of pre-rendered breadcrumbs navigation">
       <span class="nav-item">
           <a href="/components/breadcrumbs/">Initial page</a>
@@ -50,5 +49,5 @@ js:                     "/examples/breadcrumbs-js.html"
       </span>
       <span class="nav-item">buzz</span>
     </nav>
-  </header>
+  </div>
 </div>

--- a/pldoc/_components/breadcrumbs.md
+++ b/pldoc/_components/breadcrumbs.md
@@ -1,0 +1,31 @@
+---
+layout:                 pattern
+title:                  Breadcrumbs
+date:                   2016-02-29 00:00:00
+
+categories:             component
+tags:
+- atomic
+- pattern
+- js
+- breadcrumbs
+- nav
+
+slug:                   breadcrumbs
+
+url_styles:             "patterns/_breadcrumbs.scss"
+
+description:            Breadcrumb navigation.
+
+info:                   Accessible tiered navigation using breadcrumbs.
+ui-toolkit-component:   breadcrumbs
+js:                     "/examples/breadcrumbs-js.html"
+---
+<div class="breadcrumbs-basic">
+  <h2>Basic breadcrumbs</h2>
+  <div class="example-set">
+    <header class="has-breadcrumbs"></header>
+  </div>
+
+  <a class="add-breadcrumb" href="">Add breadcrumb</a>
+</div>

--- a/pldoc/_components/breadcrumbs.md
+++ b/pldoc/_components/breadcrumbs.md
@@ -21,11 +21,34 @@ info:                   Accessible tiered navigation using breadcrumbs.
 ui-toolkit-component:   breadcrumbs
 js:                     "/examples/breadcrumbs-js.html"
 ---
-<div class="breadcrumbs-basic">
+<div class="breadcrumbs-basic example-set">
   <h2>Basic breadcrumbs</h2>
-  <div class="example-set">
-    <header class="has-breadcrumbs"></header>
-  </div>
-
+  <header class="has-breadcrumbs hd-3"></header>
   <a class="add-breadcrumb" href="">Add breadcrumb</a>
+</div>
+
+<div class="breadcrumbs-prerendered example-set">
+  <h2>Pre-rendered breadcrumbs</h2>
+  <header class="has-breadcrumbs hd-3">
+    <div class="sr-is-focusable" tabindex="-1"></div>
+    <nav class="breadcrumbs list-inline" aria-label="Example of pre-rendered breadcrumbs navigation">
+      <span class="nav-item">
+          <a href="/components/breadcrumbs/">Initial page</a>
+          <span class="fa fa-angle-right" aria-hidden="true"></span>
+      </span>
+      <span class="nav-item">
+          <a href="/components/breadcrumbs/foo">foo</a>
+          <span class="fa fa-angle-right" aria-hidden="true"></span>
+      </span>
+      <span class="nav-item">
+          <a href="/components/breadcrumbs/foo/buzz">buzz</a>
+          <span class="fa fa-angle-right" aria-hidden="true"></span>
+      </span>
+      <span class="nav-item">
+          <a href="/components/breadcrumbs/foo/buzz/bar">bar</a>
+          <span class="fa fa-angle-right" aria-hidden="true"></span>
+      </span>
+      <span class="nav-item">buzz</span>
+    </nav>
+  </header>
 </div>

--- a/pldoc/_includes/examples/breadcrumbs-js.html
+++ b/pldoc/_includes/examples/breadcrumbs-js.html
@@ -11,9 +11,10 @@ define([
         'use strict';
 
         var router = new Backbone.Router();
+        var $wrapper = $('.breadcrumbs-basic');
 
         var breadcrumbsView = new BreadcrumbsView({
-            el: $('.has-breadcrumbs'),
+            el: $('.has-breadcrumbs', $wrapper),
             model: new BreadcrumbsModel({
                 breadcrumbs: [{url: '/components/breadcrumbs/', title: 'Initial page'}],
                 label: 'Example of breadcrumbs navigation'
@@ -38,7 +39,7 @@ define([
 
         // This view wraps the component you will be navigating with breadcrumbs
         new Backbone.View({
-            el: $('.breadcrumbs-basic'),
+            el: $wrapper,
             events: {
                 'click .add-breadcrumb': function(event) {
                     // You may choose to direct to the href of a link here, e.g.:

--- a/pldoc/_includes/examples/breadcrumbs-js.html
+++ b/pldoc/_includes/examples/breadcrumbs-js.html
@@ -1,0 +1,69 @@
+/**
+ * Starts the breadcrumbs example component.
+ */
+define([
+    'backbone',
+    'jquery',
+    'edx-ui-toolkit/js/breadcrumbs/breadcrumbs-view.js',
+    'edx-ui-toolkit/js/breadcrumbs/breadcrumbs-model.js'
+    ],
+    function(Backbone, $, BreadcrumbsView, BreadcrumbsModel) {
+        'use strict';
+
+        var router = new Backbone.Router();
+
+        var breadcrumbsView = new BreadcrumbsView({
+            el: $('.has-breadcrumbs'),
+            model: new BreadcrumbsModel({
+                breadcrumbs: [{url: '/components/breadcrumbs/', title: 'Initial page'}],
+                label: 'Example of breadcrumbs navigation'
+            }),
+            events: {
+                'click nav.breadcrumbs a.nav-item': function (event) {
+                    event.preventDefault();
+
+                    var url = $(event.currentTarget).attr('href'),
+                        currentCrumbs = breadcrumbsView.model.get('breadcrumbs'),
+                        indexOfCrumbClick = currentCrumbs.findIndex(function(crumb){
+                            return crumb.url === url;
+                        });
+
+                    // Remove crumbs after the one that's been clicked from the stack
+                    breadcrumbsView.model.set('breadcrumbs', currentCrumbs.slice(0, indexOfCrumbClick + 1));
+
+                    router.navigate(url, {trigger: true});
+                }
+            }
+        }).render();
+
+        // This view wraps the component you will be navigating with breadcrumbs
+        new Backbone.View({
+            el: $('.breadcrumbs-basic'),
+            events: {
+                'click .add-breadcrumb': function(event) {
+                    // You may choose to direct to the href of a link here, e.g.:
+                    // var url = $(event.currentTarget).attr('href');
+
+                    // This example instead generates a new random breadcrumb
+                    var path = window.location.pathname,
+                        crumbs = ['foo', 'bar', 'fizz', 'buzz'],
+                        randString = crumbs[Math.floor(Math.random() * crumbs.length)],
+                        url = path + (path.slice(-1) === '/' ? '' : '/') + randString;
+
+                    breadcrumbsView.model.set(
+                        'breadcrumbs',
+                        breadcrumbsView.model.get('breadcrumbs').concat([{
+                            url: url,
+                            title: randString
+                        }])
+                    );
+
+                    event.preventDefault();
+                    router.navigate(url, {trigger: true});
+                }
+            }
+        }).render();
+
+        Backbone.history.start({pushState: true});
+    }
+);

--- a/pldoc/static/js/pattern-library-doc.js
+++ b/pldoc/static/js/pattern-library-doc.js
@@ -3,6 +3,7 @@ require(
         'jquery',
         './ui.js',
         '../../_includes/examples/dropdown-menu-js.html',
+        '../../_includes/examples/breadcrumbs-js.html',
         './edx-icons.js'
     ],
     function($, Ui) {}


### PR DESCRIPTION
Refs [TNL-4599](https://openedx.atlassian.net/browse/TNL-4599)

Adds breadcrumb styling and pattern example. Uses JS components added to the UITK in [#72](https://github.com/edx/edx-ui-toolkit/pull/72).

http://ux-test.edx.org/bjacobel/breadcrumbs/

## Testing Checklist
- [x] Manually test responsive behavior.
- [ ] Manually test right-to-left behavior.
- [x] Manually test a11y support.

## Non-testing Checklist
- [x] Consider any documentation your change might need, and which users will be affected by this change.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @andy-armstrong 
- [x] @AlasdairSwan 
- [x] @clrux 
- [ ] @chris-mike 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

## TODO before merge
- [x] Merge UITK PR first
- [x] release UITK to NPM
- [x] update the UXPL `package.json` git uri to point to npm UITK v 1.2.0.