### PR TITLE
Fix icon class to use font awesome on Alerts and Form sample pages

### DIFF
--- a/pldoc/404.html
+++ b/pldoc/404.html
@@ -6,7 +6,7 @@ permalink: 404.html
 
 <div class="message message-404">
     <div class="alert alert-error" role="alert" aria-labelledby="alert-title-error" tabindex="-1">
-        <span class="icon alert-icon icon-warning" aria-hidden="true"></span>
+        <span class="icon alert-icon fa fa-warning" aria-hidden="true"></span>
 
         <div class="alert-message-with-action">
             <h3 class="alert-title" id="alert-title-error">Page not found</h3>

--- a/pldoc/_components/alerts.md
+++ b/pldoc/_components/alerts.md
@@ -22,7 +22,7 @@ info:           When something goes wrong, alerts clarify an issue and/or notify
 <div class="example-set">
     <div class="alert alert-error" role="alert" aria-labelledby="alert-title-error"
          tabindex="-1">
-        <span class="icon alert-icon icon-warning" aria-hidden="true"></span>
+        <span class="icon alert-icon fa fa-warning" aria-hidden="true"></span>
 
         <div class="alert-message-with-action">
             <h3 class="sr-only alert-title" id="alert-title-error">
@@ -44,7 +44,7 @@ info:           When something goes wrong, alerts clarify an issue and/or notify
 <div class="example-set">
     <div class="alert alert-success" role="alert" aria-labelledby="alert-title-success"
          tabindex="-1">
-        <span class="icon alert-icon icon-check" aria-hidden="true"></span>
+        <span class="icon alert-icon fa fa-check" aria-hidden="true"></span>
 
         <div class="alert-message">
             <h3 class="alert-title" id="alert-title-success">
@@ -65,7 +65,7 @@ info:           When something goes wrong, alerts clarify an issue and/or notify
 <div class="example-set">
     <div class="alert alert-warning" role="alert" aria-labelledby="alert-title-warning"
          tabindex="-1">
-        <span class="icon alert-icon icon-warning" aria-hidden="true"></span>
+        <span class="icon alert-icon fa fa-warning" aria-hidden="true"></span>
 
         <div class="alert-message-with-action">
             <h3 class="alert-title" id="alert-title-warning">
@@ -91,7 +91,7 @@ info:           When something goes wrong, alerts clarify an issue and/or notify
 <div class="example-set">
     <div class="alert alert-warning" role="alert" aria-labelledby="alert-warning-publish-title"
          tabindex="-1">
-        <span class="icon alert-icon icon-warning" aria-hidden="true"></span>
+        <span class="icon alert-icon fa fa-warning" aria-hidden="true"></span>
 
         <div class="alert-message">
             <h3 class="sr-only alert-title" id="alert-warning-publish-title">
@@ -111,7 +111,7 @@ info:           When something goes wrong, alerts clarify an issue and/or notify
 <div class="example-set">
     <div class="alert alert-information" role="alert" aria-labelledby="alert-title-information"
          tabindex="-1">
-        <span class="icon alert-icon icon-bullhorn" aria-hidden="true"></span>
+        <span class="icon alert-icon fa fa-bullhorn" aria-hidden="true"></span>
 
         <div class="alert-message">
             <h3 class="alert-title" id="alert-title-information">

--- a/pldoc/_components/buttons.md
+++ b/pldoc/_components/buttons.md
@@ -38,7 +38,7 @@ info:          Buttons should be used for performing actions within the edX envi
 <h3 class="example-set-hd">Neutral with Icons</h3>
 <div class="example-set">
     <button type="button" class="btn-neutral">
-        <span class="icon icon-comment" aria-hidden="true"></span>
+        <span class="icon fa fa-comment" aria-hidden="true"></span>
         Add your thoughts to this thread
     </button>
 </div>

--- a/pldoc/_components/forms.md
+++ b/pldoc/_components/forms.md
@@ -111,7 +111,7 @@ info:               Forms allow users to interact with the interface, set prefer
                 <label class="field-label" for="search-03">Search (with visible label and icon)</label>
                 <input class="field-input input-text" type="search" id="search-03" name="search-03" placeholder="Search this website">
                 <button class="btn-brand btn-small" type="button">
-                    <span class="icon icon-search" aria-hidden="true"></span>
+                    <span class="icon fa fa-search" aria-hidden="true"></span>
                     <span class="sr-only">Search</span>
                 </button>
             </div>


### PR DESCRIPTION
## Description

- Update icon class to font awesome on Alerts sample page.

- Update icon class to font awesome for the search icon on Form sample page.

[Preview](http://ux-test.edx.org/alisan/alert-icons-missing-in-pattern-library/components/alerts/)

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [ ] @andy-armstrong 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
