### PR TITLE
icon font family and path overlooked

### DIFF
--- a/pattern-library/sass/global/_settings.scss
+++ b/pattern-library/sass/global/_settings.scss
@@ -228,7 +228,6 @@ $open-sans-font-path: '#{$font-path}/OpenSans' !default;
 $font-family-sans-serif:    'Open Sans','Helvetica Neue', Helvetica, Arial, sans-serif !default;
 $font-family-serif:         'Georgia', Cambria, 'Times New Roman', Times, serif !default;
 $font-family-monospace:     'Bitstream Vera Sans Mono', Consolas, Courier, monospace !default;
-$icon-font:                 'edx-icons', 'Open Sans', sans-serif !default;
 
 // typography: sizes
 $font-sizes: (

--- a/pattern-library/sass/patterns/_icons.scss
+++ b/pattern-library/sass/patterns/_icons.scss
@@ -6,7 +6,6 @@
     color: currentColor;
     height: auto;
     width: auto;
-    font-family: $icon-font;
     speak: none;
     font-style: normal;
     font-weight: normal;


### PR DESCRIPTION
## Description

There is one old edx-icons font path still exist in the _icon.scss. This PR is to remove it.

- [x] @bjacobel 

[Preview](http://ux-test.edx.org/alisan/icon-font-family-fix/)

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
