### PR TITLE
Make entire repo pass ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 _preview_site
 _site
 node_modules
+!pldoc/_includes/examples
+pldoc/public

--- a/gulp/.eslintrc.json
+++ b/gulp/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "no-console": "off"
+        "no-console": "off",
+        "strict": ["error", "global"]
     }
 }

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,102 +1,104 @@
 // gulp pattern library + site configuration
 
+'use strict';
+
     // pattern library
-var patternLibrarySrc           = './pattern-library',
-    local                       = './_site',
+var patternLibrarySrc = './pattern-library',
+    local = './_site',
 
     // documentation site
-    pldocSrc                    = './pldoc',
-    pldocDest                   = pldocSrc + '/public',
+    pldocSrc = './pldoc',
+    pldocDest = pldocSrc + '/public',
 
     // example demo
-    demoSrc                     = './demo';
+    demoSrc = './demo';
 
 module.exports = {
     patternLibrary: {
-        src_files:  patternLibrarySrc + '/**/*',
+        src_files: patternLibrarySrc + '/**/*',
         src: patternLibrarySrc,
         dest: pldocDest + '/edx-pattern-library'
     },
-    browserSync:                {
-        server:                 {
+    browserSync: {
+        server: {
             // Serve up our build folder
-            baseDir:            local
+            baseDir: local
         }
     },
-    styles:                     {
+    styles: {
         // pattern library
-        rootLtrSassFile:        patternLibrarySrc + '/sass/edx-pattern-library-ltr.scss',
-        rootRtlSassFile:        patternLibrarySrc + '/sass/edx-pattern-library-rtl.scss',
-        src:                    patternLibrarySrc + '/sass',
-        dest:                   patternLibrarySrc + '/css',
-        dest_files:             patternLibrarySrc + '/css/**/*.css',
+        rootLtrSassFile: patternLibrarySrc + '/sass/edx-pattern-library-ltr.scss',
+        rootRtlSassFile: patternLibrarySrc + '/sass/edx-pattern-library-rtl.scss',
+        src: patternLibrarySrc + '/sass',
+        dest: patternLibrarySrc + '/css',
+        dest_files: patternLibrarySrc + '/css/**/*.css',
 
         // documentation site
-        pldoc_src:              pldocSrc + '/static/sass',
-        pldoc_src_files:        pldocSrc + '/static/sass/**/*.scss',
+        pldoc_src: pldocSrc + '/static/sass',
+        pldoc_src_files: pldocSrc + '/static/sass/**/*.scss',
 
         // example demo
-        demo_src:               demoSrc + '/static/sass',
-        demo_src_files:         demoSrc + '/static/sass/**/*.scss'
+        demo_src: demoSrc + '/static/sass',
+        demo_src_files: demoSrc + '/static/sass/**/*.scss'
     },
-    fonts:                      {
+    fonts: {
         // pattern library
-        src:                    patternLibrarySrc + '/fonts',
-        src_files:              patternLibrarySrc + '/fonts/**/*',
-        dest:                   pldocDest + '/fonts',
+        src: patternLibrarySrc + '/fonts',
+        src_files: patternLibrarySrc + '/fonts/**/*',
+        dest: pldocDest + '/fonts',
 
         // documentation site
-        pldoc_src:              pldocSrc + '/static/fonts',
-        pldoc_src_files:        pldocSrc + '/static/fonts/**/*',
+        pldoc_src: pldocSrc + '/static/fonts',
+        pldoc_src_files: pldocSrc + '/static/fonts/**/*',
 
         // example demo
-        demo_src:               demoSrc + '/static/fonts',
-        demo_src_files:         demoSrc + '/static/fonts/**/*'
+        demo_src: demoSrc + '/static/fonts',
+        demo_src_files: demoSrc + '/static/fonts/**/*'
     },
-    images:                     {
+    images: {
         // pattern library
-        src:                    patternLibrarySrc + '/images',
-        src_files:              patternLibrarySrc + '/images/**/*',
-        dest:                   pldocDest + '/images',
+        src: patternLibrarySrc + '/images',
+        src_files: patternLibrarySrc + '/images/**/*',
+        dest: pldocDest + '/images',
 
         // documentation site
-        pldoc_src:              pldocSrc + '/static/images',
-        pldoc_src_files:        pldocSrc + '/static/images/**/*',
+        pldoc_src: pldocSrc + '/static/images',
+        pldoc_src_files: pldocSrc + '/static/images/**/*',
 
         // example demo
-        demo_src:               demoSrc + '/static/images',
-        demo_src_files:         demoSrc + '/static/images/**/*'
+        demo_src: demoSrc + '/static/images',
+        demo_src_files: demoSrc + '/static/images/**/*'
     },
-    scripts:                    {
+    scripts: {
         // pattern library
-        src:                    patternLibrarySrc + '/js',
-        src_files:              patternLibrarySrc + '/js/**/*.js',
-        dest:                   pldocDest + '/js',
+        src: patternLibrarySrc + '/js',
+        src_files: patternLibrarySrc + '/js/**/*.js',
+        dest: pldocDest + '/js',
 
         // documentation site
-        pldoc_src:              pldocSrc + '/static/js',
-        pldoc_src_files:        pldocSrc + '/static/js/**/*.js',
+        pldoc_src: pldocSrc + '/static/js',
+        pldoc_src_files: pldocSrc + '/static/js/**/*.js',
 
         // example demo
-        demo_src:               demoSrc + '/static/js',
-        demo_src_files:         demoSrc + '/static/js/**/*.js'
+        demo_src: demoSrc + '/static/js',
+        demo_src_files: demoSrc + '/static/js/**/*.js'
     },
-    exampleHtmlFiles:           {
-        pldoc_src_files:        pldocSrc + '/_includes/examples/*.html'
+    exampleHtmlFiles: {
+        pldoc_src_files: pldocSrc + '/_includes/examples/*.html'
     },
-    lib:                    {
+    lib: {
         // third party libraries
-        src:                    './node_modules'
+        src: './node_modules'
     },
-    jekyll:                     {
-        home:                   './pldoc/index.html',
-        posts:                  './pldoc/_posts/**/*',
-        components:             './pldoc/_components/**/*',
-        design_elements:        './pldoc/_design_elements/**/*',
-        includes:               './pldoc/_includes/**/*',
-        examples:               './pldoc/examples/**/*',
-        demo:                   './pldoc/demo/**/*.html',
-        layouts:                './pldoc/_layouts/**/*'
+    jekyll: {
+        home: './pldoc/index.html',
+        posts: './pldoc/_posts/**/*',
+        components: './pldoc/_components/**/*',
+        design_elements: './pldoc/_design_elements/**/*',
+        includes: './pldoc/_includes/**/*',
+        examples: './pldoc/examples/**/*',
+        demo: './pldoc/demo/**/*.html',
+        layouts: './pldoc/_layouts/**/*'
     },
     documentation: {
         rootJavaScriptFile: './pldoc/static/js/pattern-library-doc.js',

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -1,6 +1,8 @@
-var gulp            = require('gulp'),
-    browserSync     = require('browser-sync'),
-    config          = require('../config').browserSync;
+'use strict';
+
+var gulp = require('gulp'),
+    browserSync = require('browser-sync'),
+    config = require('../config').browserSync;
 
 gulp.task('browserSync', ['jekyll-build'], function() {
     browserSync(config);

--- a/gulp/tasks/build-development.js
+++ b/gulp/tasks/build-development.js
@@ -1,20 +1,18 @@
-(function() {
-    'use strict';
+'use strict';
 
-    var gulp = require('gulp'),
-        runSequence = require('run-sequence');
+var gulp = require('gulp'),
+    runSequence = require('run-sequence');
 
-    gulp.task('build-development', function(callback) {
-        runSequence(
-            'fonts',
-            'images',
-            'scripts',
-            'pldoc-scripts',
-            'demo-scripts',
-            'demo-styles',
-            'copy-pattern-library',
-            'webpack',
-            callback
-        );
-    });
-})();
+gulp.task('build-development', function(callback) {
+    runSequence(
+        'fonts',
+        'images',
+        'scripts',
+        'pldoc-scripts',
+        'demo-scripts',
+        'demo-styles',
+        'copy-pattern-library',
+        'webpack',
+        callback
+    );
+});

--- a/gulp/tasks/build-production.js
+++ b/gulp/tasks/build-production.js
@@ -1,15 +1,14 @@
-(function() {
-    'use strict';
+'use strict';
 
-    var gulp = require('gulp'),
-        runSequence = require('run-sequence');
+var gulp = require('gulp'),
+    runSequence = require('run-sequence');
 
-    gulp.task('build-production', function(callback) {
-        runSequence(
-            'clean',
-            'build-development',
-            'scripts-uglify',
-            'webpack',
-            callback);
-    });
-})();
+gulp.task('build-production', function(callback) {
+    runSequence(
+        'clean',
+        'build-development',
+        'scripts-uglify',
+        'webpack',
+        callback
+    );
+});

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var gulp    = require('gulp'),
-    config  = require('../config'),
-    del     = require('del');
+var gulp = require('gulp'),
+    config = require('../config'),
+    del = require('del');
 
 gulp.task('clean', function() {
     return del([

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var gulp            = require('gulp'),
-    runSequence     = require('run-sequence');
+var gulp = require('gulp'),
+    runSequence = require('run-sequence');
 
 gulp.task('default', function(cb) {
     runSequence(
         'build-development',
         'watch',
-        cb);
+        cb
+    );
 });

--- a/gulp/tasks/demo_scripts.js
+++ b/gulp/tasks/demo_scripts.js
@@ -1,16 +1,15 @@
 'use strict';
 
-var gulp            = require('gulp'),
-    browserSync     = require('browser-sync'),
-    config          = require('../config').scripts,
-    uglify          = require('gulp-uglify');
+var gulp = require('gulp'),
+    browserSync = require('browser-sync'),
+    config = require('../config').scripts,
+    uglify = require('gulp-uglify');
 
-gulp.task('demo-scripts', ['lint'], function() {
+gulp.task('demo-scripts', ['lint-src'], function() {
     return gulp.src([
-            // setup script sequence
-            config.demo_src + '/pattern-library.js'
-        ])
-        .pipe(uglify())
-        .pipe(browserSync.reload({stream: true}))
-        .pipe(gulp.dest(config.dest));
+        // setup script sequence
+        config.demo_src + '/pattern-library.js'
+    ]).pipe(uglify())
+    .pipe(browserSync.reload({stream: true}))
+    .pipe(gulp.dest(config.dest));
 });

--- a/gulp/tasks/demo_styles.js
+++ b/gulp/tasks/demo_styles.js
@@ -6,11 +6,9 @@ var gulp = require('gulp'),
     webpackUtil = require('../util/webpack');
 
 gulp.task('demo-styles', function() {
-    return webpackUtil.packageCss(
-        {
-            source: config.documentation.rootDemoSassFile,
-            targetDirectory: config.documentation.pldocDest,
-            patternLibraryPath: '/public/edx-pattern-library'
-        })
-        .pipe(browserSync.stream());
+    return webpackUtil.packageCss({
+        source: config.documentation.rootDemoSassFile,
+        targetDirectory: config.documentation.pldocDest,
+        patternLibraryPath: '/public/edx-pattern-library'
+    }).pipe(browserSync.stream());
 });

--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var gulp            = require('gulp'),
-    browserSync     = require('browser-sync'),
-    changed         = require('gulp-changed'),
-    config          = require('../config').fonts,
-    merge           = require('merge-stream');
+var gulp = require('gulp'),
+    browserSync = require('browser-sync'),
+    changed = require('gulp-changed'),
+    config = require('../config').fonts,
+    merge = require('merge-stream');
 
 gulp.task('fonts', function() {
-
     var fonts = gulp.src(config.src_files),
         pldocFonts = gulp.src(config.pldoc_src_files),
         demoFonts = gulp.src(config.demo_src_files);

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var gulp            = require('gulp'),
-    browserSync     = require('browser-sync'),
-    changed         = require('gulp-changed'),
-    config          = require('../config').images,
-    merge           = require('merge-stream');
+var gulp = require('gulp'),
+    browserSync = require('browser-sync'),
+    changed = require('gulp-changed'),
+    config = require('../config').images,
+    merge = require('merge-stream');
 
 gulp.task('images', function() {
-
     var images = gulp.src(config.src_files),
         pldocImages = gulp.src(config.pldoc_src_files),
         demoImages = gulp.src(config.demo_src_files);

--- a/gulp/tasks/jekyll-build.js
+++ b/gulp/tasks/jekyll-build.js
@@ -1,8 +1,9 @@
-var gulp    = require('gulp'),
-    config  = require('../config').jekyll,
-    cp      = require('child_process');
+'use strict';
 
-gulp.task('jekyll-build', function (done) {
+var gulp = require('gulp'),
+    cp = require('child_process');
+
+gulp.task('jekyll-build', function(done) {
     return cp.spawn('jekyll', ['build'], {stdio: 'inherit'})
         .on('close', done);
 });

--- a/gulp/tasks/jekyll-rebuild.js
+++ b/gulp/tasks/jekyll-rebuild.js
@@ -1,8 +1,8 @@
-var gulp            = require('gulp'),
-    browserSync     = require('browser-sync'),
-    config          = require('../config').jekyll,
-    cp              = require('child_process');
+'use strict';
 
-gulp.task('jekyll-rebuild', ['jekyll-build'], function () {
+var gulp = require('gulp'),
+    browserSync = require('browser-sync');
+
+gulp.task('jekyll-rebuild', ['jekyll-build'], function() {
     browserSync.reload();
 });

--- a/gulp/tasks/pldoc.js
+++ b/gulp/tasks/pldoc.js
@@ -9,7 +9,7 @@ var gulp = require('gulp'),
     ghPages = require('gulp-gh-pages'),
     runSequence = require('run-sequence');
 
-gulp.task('pldoc-scripts', ['lint'], function() {
+gulp.task('pldoc-scripts', ['lint-src'], function() {
     return gulp.src([configScripts.pldoc_src + '/**.js'])
         .pipe(uglify())
         .pipe(browserSync.reload({stream: true}))
@@ -35,8 +35,7 @@ gulp.task('pldoc-scripts', function() {
             source: config.documentation.rootJavaScriptFile,
             targetDirectory: config.documentation.pldocDest
         }
-    )
-        .pipe(browserSync.stream());
+    ).pipe(browserSync.stream());
 });
 
 gulp.task('pldoc-styles', function() {
@@ -46,8 +45,7 @@ gulp.task('pldoc-styles', function() {
             targetDirectory: config.documentation.pldocDest,
             patternLibraryPath: '/public/edx-pattern-library'
         }
-    )
-        .pipe(browserSync.stream());
+    ).pipe(browserSync.stream());
 });
 
 gulp.task('doc-publish', ['jekyll-build'], function() {

--- a/gulp/tasks/scripts-lint.js
+++ b/gulp/tasks/scripts-lint.js
@@ -1,23 +1,21 @@
-(function() {
-    'use strict';
+'use strict';
 
-    var gulp            = require('gulp'),
-        eslint          = require('gulp-eslint'),
-        config          = require('../config').scripts,
-        htmlFiles       = require('../config').exampleHtmlFiles,
-        handleErrors    = require('../util/handleErrors'),
-        merge           = require('merge-stream');
+var gulp = require('gulp'),
+    shell = require('gulp-shell'),
+    eslint = require('gulp-eslint'),
+    config = require('../config').scripts,
+    htmlFiles = require('../config').exampleHtmlFiles,
+    merge = require('merge-stream');
 
-    gulp.task('lint', function() {
+gulp.task('lint', shell.task('eslint .'));
 
-        var scripts = gulp.src(config.src_files),
-            pldocScripts = gulp.src(config.pldoc_src_files),
-            pldocHtmlFiles = gulp.src(htmlFiles.pldoc_src_files);
+gulp.task('lint-src', function() {
+    var scripts = gulp.src(config.src_files),
+        pldocScripts = gulp.src(config.pldoc_src_files),
+        pldocHtmlFiles = gulp.src(htmlFiles.pldoc_src_files);
 
-        return merge(scripts, pldocScripts, pldocHtmlFiles)
-            .pipe(eslint())
-            .pipe(eslint.format())
-            .pipe(eslint.failAfterError());
-    });
-
-}());
+    return merge(scripts, pldocScripts, pldocHtmlFiles)
+        .pipe(eslint())
+        .pipe(eslint.format())
+        .pipe(eslint.failAfterError());
+});

--- a/gulp/tasks/scripts-uglify.js
+++ b/gulp/tasks/scripts-uglify.js
@@ -1,10 +1,12 @@
-var gulp         = require('gulp'),
-    config       = require('../config').scripts,
-    size         = require('gulp-filesize'),
-    uglify       = require('gulp-uglify');
+'use strict';
+
+var gulp = require('gulp'),
+    config = require('../config').scripts,
+    size = require('gulp-filesize'),
+    uglify = require('gulp-uglify');
 
 gulp.task('scripts-uglify', function() {
-  return gulp.src(config.dest)
-    .pipe(uglify())
-    .pipe(size());
+    return gulp.src(config.dest)
+        .pipe(uglify())
+        .pipe(size());
 });

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -1,17 +1,16 @@
 'use strict';
 
-var gulp            = require('gulp'),
-    browserSync     = require('browser-sync'),
-    config          = require('../config'),
-    uglify          = require('gulp-uglify');
+var gulp = require('gulp'),
+    browserSync = require('browser-sync'),
+    config = require('../config'),
+    uglify = require('gulp-uglify');
 
-gulp.task('scripts', ['lint'], function() {
+gulp.task('scripts', ['lint-src'], function() {
     return gulp.src([
-            // setup script sequence
-            config.scripts.src + '/select-replace.js',
-            config.scripts.src + '/testing.js'
-        ])
-        .pipe(uglify())
-        .pipe(browserSync.reload({stream: true}))
-        .pipe(gulp.dest(config.scripts.dest));
+        // setup script sequence
+        config.scripts.src + '/select-replace.js',
+        config.scripts.src + '/testing.js'
+    ]).pipe(uglify())
+    .pipe(browserSync.reload({stream: true}))
+    .pipe(gulp.dest(config.scripts.dest));
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,8 +1,9 @@
-var gulp    = require('gulp'),
-    config  = require('../config');
+'use strict';
+
+var gulp = require('gulp'),
+    config = require('../config');
 
 gulp.task('watch', ['browserSync'], function() {
-
     // patterns and documentation site
     gulp.watch(config.styles.src_files, ['pldoc-styles', 'demo-styles', 'styles']);
     gulp.watch(config.styles.pldoc_src_files, ['pldoc-styles']);

--- a/gulp/util/bundleLogger.js
+++ b/gulp/util/bundleLogger.js
@@ -2,9 +2,10 @@
 
 // Provides gulp style logs to the bundle method in browserify.js
 
+'use strict';
 
-var gutil         = require('gulp-util');
-var prettyHrtime  = require('pretty-hrtime');
+var gutil = require('gulp-util');
+var prettyHrtime = require('pretty-hrtime');
 var startTime;
 
 module.exports = {

--- a/gulp/util/gitUtils.js
+++ b/gulp/util/gitUtils.js
@@ -1,16 +1,14 @@
-(function() {
-    'use strict';
+'use strict';
 
-    var childProcess = require('child_process'),
-        gitBranchCommand = 'git rev-parse --abbrev-ref HEAD';
+var childProcess = require('child_process');
+var gitBranchCommand = 'git rev-parse --abbrev-ref HEAD';
 
-    module.exports = {
-        /**
-         * Returns the current Git branch for the current directory.
-         */
-        currentBranch: function() {
-            var branch = childProcess.execSync(gitBranchCommand);
-            return branch.toString().trim();
-        }
-    };
-})();
+module.exports = {
+    /**
+     * Returns the current Git branch for the current directory.
+     */
+    currentBranch: function() {
+        var branch = childProcess.execSync(gitBranchCommand);
+        return branch.toString().trim();
+    }
+};

--- a/gulp/util/handleErrors.js
+++ b/gulp/util/handleErrors.js
@@ -1,13 +1,14 @@
-var notify = require("gulp-notify");
+'use strict';
+
+var notify = require('gulp-notify');
 
 module.exports = function() {
-
     var args = Array.prototype.slice.call(arguments);
 
     // Send error to notification center with gulp-notify
     notify.onError({
-        title: "Compile Error",
-        message: "<%= error %>"
+        title: 'Compile Error',
+        message: '<%= error %>'
     }).apply(this, args);
 
     // Keep gulp from hanging on this task

--- a/gulp/util/webpack.js
+++ b/gulp/util/webpack.js
@@ -1,74 +1,72 @@
-(function() {
-    'use strict';
+'use strict';
 
-    var gulp = require('gulp'),
-        webpack = require('webpack-stream'),
-        gulpIgnore = require('gulp-ignore'),
-        ExtractTextPlugin = require('extract-text-webpack-plugin'),
-        path = require('path'),
-        _ = require('underscore');
+var gulp = require('gulp'),
+    webpack = require('webpack-stream'),
+    gulpIgnore = require('gulp-ignore'),
+    ExtractTextPlugin = require('extract-text-webpack-plugin'),
+    path = require('path'),
+    _ = require('underscore'),
+    webpackConfigJS = require('../../webpack.config.js'),
+    webpackConfigCSS = require('../../webpack.css.config.js');
 
-    module.exports = {
-        /**
-         * Packages a JavaScript file using Webpack.
-         */
-        packageJavaScript: function(options) {
-            var webpackConfig = require('../../webpack.config.js'),
-                sourceExtension = path.extname(options.source),
-                targetExtension = '.js',
-                baseName = path.basename(options.source, sourceExtension),
-                packageConfig = _.extend(
-                    {},
-                    webpackConfig,
-                    {
-                        output: _.extend(
-                            {},
-                            webpackConfig.output,
-                            {
-                                filename: baseName + targetExtension,
-                                chunkFilename: baseName + '-[id]' + targetExtension
-                            }
-                        ),
-                        plugins: [
-                            new ExtractTextPlugin(baseName + targetExtension)
-                        ]
-                    }
-                );
-            return gulp.src(options.source)
-                .pipe(webpack(packageConfig))
-                .pipe(gulp.dest(options.targetDirectory));
-        },
-
-        /**
-         * Packages a CSS file using Webpack.
-         */
-        packageCss: function(options) {
-            var webpackConfig = require('../../webpack.css.config.js'),
-                sourceExtension = path.extname(options.source),
-                targetExtension = '.css',
-                baseName = path.basename(options.source, sourceExtension),
-                targetPath = '../../' + options.targetDirectory + '/' + baseName + targetExtension,
-                targetFile = path.resolve(__dirname, targetPath),
-                patternLibraryPath = options.patternLibraryPath,
-                packageConfig = _.extend(
-                    {},
-                    webpackConfig,
-                    {
-                        entry: {},
-                        output: {
-                            filename: targetFile,
+module.exports = {
+    /**
+     * Packages a JavaScript file using Webpack.
+     */
+    packageJavaScript: function(options) {
+        var sourceExtension = path.extname(options.source),
+            targetExtension = '.js',
+            baseName = path.basename(options.source, sourceExtension),
+            packageConfig = _.extend(
+                {},
+                webpackConfigJS,
+                {
+                    output: _.extend(
+                        {},
+                        webpackConfigJS.output,
+                        {
+                            filename: baseName + targetExtension,
                             chunkFilename: baseName + '-[id]' + targetExtension
                         }
+                    ),
+                    plugins: [
+                        new ExtractTextPlugin(baseName + targetExtension)
+                    ]
+                }
+            );
+        return gulp.src(options.source)
+            .pipe(webpack(packageConfig))
+            .pipe(gulp.dest(options.targetDirectory));
+    },
+
+    /**
+     * Packages a CSS file using Webpack.
+     */
+    packageCss: function(options) {
+        var sourceExtension = path.extname(options.source),
+            targetExtension = '.css',
+            baseName = path.basename(options.source, sourceExtension),
+            targetPath = '../../' + options.targetDirectory + '/' + baseName + targetExtension,
+            targetFile = path.resolve(__dirname, targetPath),
+            patternLibraryPath = options.patternLibraryPath,
+            packageConfig = _.extend(
+                {},
+                webpackConfigCSS,
+                {
+                    entry: {},
+                    output: {
+                        filename: targetFile,
+                        chunkFilename: baseName + '-[id]' + targetExtension
                     }
-                );
-            if (patternLibraryPath) {
-                packageConfig.sassLoader.data = '$pattern-library-path: \'' + patternLibraryPath + '\' !default;';
-            }
-            packageConfig.entry[baseName + targetExtension] = path.resolve(__dirname, '../../' + options.source);
-            return gulp.src('')
-                .pipe(webpack(packageConfig))
-                .pipe(gulpIgnore.exclude('**/*.js'))  // Exclude JavaScript files that are generated
-                .pipe(gulp.dest(options.targetDirectory));
+                }
+            );
+        if (patternLibraryPath) {
+            packageConfig.sassLoader.data = '$pattern-library-path: \'' + patternLibraryPath + '\' !default;';
         }
-    };
-})();
+        packageConfig.entry[baseName + targetExtension] = path.resolve(__dirname, '../../' + options.source);
+        return gulp.src('')
+            .pipe(webpack(packageConfig))
+            .pipe(gulpIgnore.exclude('**/*.js'))  // Exclude JavaScript files that are generated
+            .pipe(gulp.dest(options.targetDirectory));
+    }
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,4 +12,4 @@
 var requireDir = require('require-dir');
 
 // Require all tasks in gulp/tasks, including subfolders
-requireDir('./gulp/tasks', { recurse: true });
+requireDir('./gulp/tasks', {recurse: true});

--- a/package.json
+++ b/package.json
@@ -53,12 +53,14 @@
     "gulp-minify-css": "*",
     "gulp-notify": "*",
     "gulp-rename": "*",
+    "gulp-shell": "^0.5.2",
     "gulp-uglify": "*",
     "gulp-util": "*",
     "lodash": "*",
     "merge-stream": "*",
     "minimist": "*",
     "node-sass": "~3.7.0",
+    "pretty-hrtime": "^1.0.2",
     "require-dir": "*",
     "run-sequence": "*",
     "sass-loader": "~3.2.0",
@@ -73,6 +75,6 @@
     "production": "gulp build-production",
     "gulp": "gulp",
     "development": "gulp build-development",
-    "lint": "gulp lint"
+    "lint": "eslint ."
   }
 }

--- a/pldoc/demo/static/js/pattern-library.js
+++ b/pldoc/demo/static/js/pattern-library.js
@@ -1,16 +1,16 @@
 require.config({
     baseUrl: '/public/js',
     paths: {
-        jquery: "/public/js/jquery.min",
-        modernizr: "/public/js/modernizr-custom",
-        afontgarde: "/public/js/afontgarde",
-        edxicons: "/public/js/edx-icons"
+        jquery: '/public/js/jquery.min',
+        modernizr: '/public/js/modernizr-custom',
+        afontgarde: '/public/js/afontgarde',
+        edxicons: '/public/js/edx-icons'
     },
     shim: {
-        'jquery': {
+        jquery: {
             exports: 'jquery'
         },
-        'afontgarde': {
+        afontgarde: {
             exports: 'AFontGarde'
         }
     }
@@ -22,6 +22,8 @@ require([
     '/public/js/modernizr-custom.js',
     'afontgarde',
     '/public/js/edx-icons.js'
-    ],
-    function($, Ui) {}
+],
+    function() {
+        'use strict';
+    }
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,39 +1,51 @@
-(function() {
-    'use strict';
+/* eslint "strict": ["error", "global"] */
 
-    var path = require('path'),
-        Webpack = require('webpack'),
-        outputRoot = process.env.OUTPUT_ROOT !== undefined ? process.env.OUTPUT_ROOT : 'pldoc/public/',
-        siteRoot = process.env.SITE_ROOT !== undefined ? process.env.SITE_ROOT : '/',
-        publicJavaScriptRoot = 'public/';
+'use strict';
 
-    module.exports = {
-        output: {
-            path: path.resolve(__dirname, outputRoot),
-            publicPath: siteRoot + publicJavaScriptRoot
-        },
-        module: {
-            loaders: [
-              { test: /.woff([\?]?.*)$/, loader: "url-loader?limit=10000&mimetype=application/font-woff&name=[path][name].[ext]" },
-              { test: /.ttf([\?]?.*)$/,  loader: "url-loader?limit=10000&mimetype=application/octet-stream&name=[path][name].[ext]" },
-              { test: /.eot([\?]?.*)$/,  loader: "file-loader?name=[path][name].[ext]" },
-              { test: /.svg([\?]?.*)$/,  loader: "url-loader?limit=10000&mimetype=image/svg+xml&name=[path][name].[ext]" }
-            ]
-        },
-        modulesDirectories: ['node_modules'],
-        resolve: {
-            alias: {
-                'edx-pattern-library': path.resolve(__dirname, 'pattern-library'),
-                'edx-ui-toolkit': path.resolve(__dirname, 'node_modules/edx-ui-toolkit/src')
+var path = require('path'),
+    Webpack = require('webpack'),
+    outputRoot = process.env.OUTPUT_ROOT !== undefined ? process.env.OUTPUT_ROOT : 'pldoc/public/',
+    siteRoot = process.env.SITE_ROOT !== undefined ? process.env.SITE_ROOT : '/',
+    publicJavaScriptRoot = 'public/';
+
+module.exports = {
+    output: {
+        path: path.resolve(__dirname, outputRoot),
+        publicPath: siteRoot + publicJavaScriptRoot
+    },
+    module: {
+        loaders: [
+            {
+                test: /.woff([\?]?.*)$/,
+                loader: 'url-loader?limit=10000&mimetype=application/font-woff&name=[path][name].[ext]'
+            },
+            {
+                test: /.ttf([\?]?.*)$/,
+                loader: 'url-loader?limit=10000&mimetype=application/octet-stream&name=[path][name].[ext]'
+            },
+            {
+                test: /.eot([\?]?.*)$/,
+                loader: 'file-loader?name=[path][name].[ext]'
+            },
+            {
+                test: /.svg([\?]?.*)$/,
+                loader: 'url-loader?limit=10000&mimetype=image/svg+xml&name=[path][name].[ext]'
             }
-        },
-        plugins: [
-            new Webpack.ProvidePlugin({
-                $: 'jquery'
-            }),
-            new Webpack.IgnorePlugin(/^(config.js)$/)
-        ],
-        debug: true,
-        devtool: 'inline-source-map'
-    };
-})();
+        ]
+    },
+    modulesDirectories: ['node_modules'],
+    resolve: {
+        alias: {
+            'edx-pattern-library': path.resolve(__dirname, 'pattern-library'),
+            'edx-ui-toolkit': path.resolve(__dirname, 'node_modules/edx-ui-toolkit/src')
+        }
+    },
+    plugins: [
+        new Webpack.ProvidePlugin({
+            $: 'jquery'
+        }),
+        new Webpack.IgnorePlugin(/^(config.js)$/)
+    ],
+    debug: true,
+    devtool: 'inline-source-map'
+};

--- a/webpack.css.config.js
+++ b/webpack.css.config.js
@@ -1,29 +1,29 @@
-(function() {
-    'use strict';
+/* eslint "strict": ["error", "global"] */
 
-    var path = require('path'),
-        ExtractTextPlugin = require('extract-text-webpack-plugin');
+'use strict';
 
-    module.exports = {
-        modulesDirectories: ['node_modules'],
-        module: {
-            loaders: [
-                {
-                    test: /\.scss$/,
-                    loader: ExtractTextPlugin.extract('style', 'css!sass')
-                }
-            ]
-        },
-        plugins: [
-            new ExtractTextPlugin('[name]')
-        ],
-        sassLoader: {
-            includePaths: [
-                path.resolve(__dirname, './node_modules'),
-                path.resolve(__dirname, './node_modules/edx-pattern-library/node_modules')
-            ]
-        },
-        debug: true,
-        devtool: 'inline-source-map'
-    };
-})();
+var path = require('path'),
+    ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+    modulesDirectories: ['node_modules'],
+    module: {
+        loaders: [
+            {
+                test: /\.scss$/,
+                loader: ExtractTextPlugin.extract('style', 'css!sass')
+            }
+        ]
+    },
+    plugins: [
+        new ExtractTextPlugin('[name]')
+    ],
+    sassLoader: {
+        includePaths: [
+            path.resolve(__dirname, './node_modules'),
+            path.resolve(__dirname, './node_modules/edx-pattern-library/node_modules')
+        ]
+    },
+    debug: true,
+    devtool: 'inline-source-map'
+};


### PR DESCRIPTION
## Description
Previously we were linting only a small subset of "source" files and not including some directories that contained a lot of JS code (notably `./gulp`). This lints the whole repo, and fixes all the existing lint violations. 

(I went ahead and did this because my editor has no way to turn off linting on a per-file basis, and all the red in the gulp scripts was making it hard to concentrate while debugging other issues.)

## Reviewers
- [x] @andy-armstrong 
- [x] @alisan617 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

