### PR TITLE
Changlog and production build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - - -
 
+## 0.16.2 (2016-07-29)
+* Updated our color options and the swatch layout
+* Fixed regressions throughout as a result of the changed colors
+* Updated alerts to meet more needs of the UX team
+
 ## 0.16.1 (2016-07-15)
 * Remove edx-icons font variable
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-pattern-library",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "authors": [
     "edX Pattern Library Team <pattern-library@edx.org>"
   ],


### PR DESCRIPTION
Release branch. Working branch already had thumbs, but neglected to include the bower and CHANGELOG updates. This brings those two things in.