### PR TITLE
Update styling for search box

### DIFF
--- a/pattern-library/sass/_normalize.scss
+++ b/pattern-library/sass/_normalize.scss
@@ -355,21 +355,9 @@ input[type="number"]::-webkit-outer-spin-button {
  */
 
 input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box; /* 2 */
   box-sizing: content-box;
-}
-
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
 }
 
 /**

--- a/pattern-library/sass/patterns/_forms.scss
+++ b/pattern-library/sass/patterns/_forms.scss
@@ -257,6 +257,15 @@ $input-width: (
             border-color: palette(error, text);
         }
     }
+
+    // Input fields immediately followed by a button (ie, search boxes) should eliminate the spacing
+    // between them and adopt matching styling/sizing to emphasize that they are connected.
+    &[type=search] + button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        font-size: font-size(base);
+        margin-left: (-1 * $baseline / 4);
+    }
 }
 
 

--- a/pldoc/_components/forms.md
+++ b/pldoc/_components/forms.md
@@ -111,8 +111,9 @@ info:               Forms allow users to interact with the interface, set prefer
                 <label class="field-label" for="search-03">Search (with visible label and icon)</label>
                 <input class="field-input input-text" type="search" id="search-03" name="search-03" placeholder="Search this website">
                 <button class="btn-brand btn-small" type="button">
-                    <span class="icon fa fa-search" aria-hidden="true"></span>
-                    <span class="sr-only">Search</span>
+                    <span class="icon fa fa-search" aria-hidden="true">
+                        <span class="sr-only">Search</span>
+                    </span>
                 </button>
             </div>
         </fieldset>


### PR DESCRIPTION
## Description

Updates styling of `<button>`s immediately following `<input>`s to remove spacing between them and match styling and sizing.

http://ux-test.edx.org/bjacobel/search-tweaks/components/forms/

![](https://i.bjacobel.com/20160801-oewr9.png)

(old: [spacing between box and button, rounded corners, mismatched sizes](https://i.bjacobel.com/20160801-zcawc.png))

Checked in FFX, Safari and Chrome and confirmed the styling is consistent.
  
## Manual Test Plan

## Testing Checklist
- [ ] Manually test responsive behavior.
- ~~Manually test right-to-left behavior.~~ N/A
- [x] Manually test a11y support.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [ ] @andy-armstrong 
- [x] @chris-mike 
- [x] @clrux 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

