### PR TITLE
Avoid underlining all anchor elements

### DIFF
--- a/pattern-library/sass/global/_helpers.scss
+++ b/pattern-library/sass/global/_helpers.scss
@@ -133,7 +133,6 @@
     &:active,
     &:focus {
         color: $link-focus-color;
-        text-decoration: underline;
     }
 
     // STATE: is disabled


### PR DESCRIPTION
@andy-armstrong @clrux I think this would prevent all anchor elements on pattern library pages from being underlined on hover. I'm not sure why this was introduced.