### PR TITLE
Clean up button styles and documentation

### DIFF
--- a/pattern-library/sass/patterns/_buttons.scss
+++ b/pattern-library/sass/patterns/_buttons.scss
@@ -80,6 +80,13 @@ $btn-small-font-size: font-size(small);
             margin-right: 0;
         }
     }
+
+    // Don't show underlines on links that are styled as buttons
+    &:hover,
+    &:active,
+    &:focus {
+        text-decoration: none;
+    }
 }
 
 
@@ -114,8 +121,8 @@ $btn-small-font-size: font-size(small);
     &:focus,
     &.is-focused {
         border-color: palette(primary, accent);
-        background: palette(primary, x-back);
-        color: palette(primary, accent);
+        background: palette(primary, accent);
+        color: palette(primary, x-back);
     }
 
     // STATE: is pressed or active
@@ -150,8 +157,8 @@ $btn-small-font-size: font-size(small);
     &.is-hovered,
     &:focus,
     &.is-focused {
+        border-color: palette(primary, accent);
         background: palette(primary, accent);
-        border-color: palette(primary, base);
         color: palette(primary, x-back);
     }
 
@@ -297,8 +304,8 @@ $btn-small-font-size: font-size(small);
         }
 
         &:only-child {
-          @include margin-left(0);
-          border-radius: $btn-border-radius;
+            @include margin-left(0);
+            border-radius: $btn-border-radius;
         }
     }
 }

--- a/pldoc/_components/buttons.md
+++ b/pldoc/_components/buttons.md
@@ -35,27 +35,12 @@ info:          Buttons should be used for performing actions within the edX envi
     <button type="button" class="btn-neutral" disabled>Neutral Disabled</button>
 </div>
 
-<h3 class="example-set-hd">Neutral with Icons</h3>
-<div class="example-set">
-    <button type="button" class="btn-neutral">
-        <span class="icon fa fa-comment" aria-hidden="true"></span>
-        Add your thoughts to this thread
-    </button>
-</div>
-
 <h3 class="example-set-hd">Brand</h3>
 <div class="example-set">
     <button type="button" class="btn-brand">Primary</button>
     <button type="button" class="btn-brand btn-large">Primary Large</button>
     <button type="button" class="btn-brand btn-small">Primary Small</button>
     <button type="button" class="btn-brand" disabled>Primary Disabled</button>
-</div>
-
-<h3 class="example-set-hd">Links</h3>
-<div class="example-set">
-    <button type="button" class="btn-link">Link</button>
-    <button type="button" class="btn-link btn-large">Link Large</button>
-    <button type="button" class="btn-link btn-small">Link Small</button>
 </div>
 
 <h3 class="example-set-hd">Elevated</h3>
@@ -66,22 +51,24 @@ info:          Buttons should be used for performing actions within the edX envi
     <button type="button" class="btn-elevated" disabled>Elevated Disabled</button>
 </div>
 
-<h3 class="example-set-hd">Inverse</h3>
+<h3 class="example-set-hd">Buttons with icons</h3>
 <div class="example-set">
-    <div class="button-overlay-demo">
-        <button type="button" class="btn-inverse">Inverse</button>
-        <button type="button" class="btn-inverse btn-large">Inverse Large</button>
-        <button type="button" class="btn-inverse btn-small">Inverse Small</button>
-        <button type="button" class="btn-inverse" disabled>Inverse Disabled</button>
-    </div>
-</div>
-
-<h3 class="example-set-hd">Links with Visual Styling Applied</h3>
-<div class="example-set">
-    <a href="http://ux.edx.org/" class="btn">View the UX Pattern Library</a>
-    <a href="http://ux.edx.org/" class="btn-neutral">View the UX Pattern Library</a>
-    <a href="http://ux.edx.org/" class="btn-brand">View the UX Pattern Library</a>
-    <a href="http://ux.edx.org/" class="btn-elevated">View the UX Pattern Library</a>
+    <button type="button" class="btn">
+        <span class="icon fa fa-comment" aria-hidden="true"></span>
+        Default
+    </button>
+    <button type="button" class="btn-neutral">
+        <span class="icon fa fa-comment" aria-hidden="true"></span>
+        Neutral
+    </button>
+    <button type="button" class="btn-brand">
+        <span class="icon fa fa-comment" aria-hidden="true"></span>
+        Brand
+    </button>
+    <button type="button" class="btn-elevated">
+        <span class="icon fa fa-comment" aria-hidden="true"></span>
+        Elevated
+    </button>
 </div>
 
 <h3 class="example-set-hd">Combo</h3>
@@ -98,4 +85,29 @@ info:          Buttons should be used for performing actions within the edX envi
         <button type="button" class="btn">Edit</button>
         <button type="button" class="btn">Preview</button>
     </div>
+</div>
+
+<h3 class="example-set-hd">Inverse</h3>
+<div class="example-set">
+    <div class="button-overlay-demo">
+        <button type="button" class="btn-inverse">Inverse</button>
+        <button type="button" class="btn-inverse btn-large">Inverse Large</button>
+        <button type="button" class="btn-inverse btn-small">Inverse Small</button>
+        <button type="button" class="btn-inverse" disabled>Inverse Disabled</button>
+    </div>
+</div>
+
+<h3 class="example-set-hd">Links with visual styling applied</h3>
+<div class="example-set">
+    <a href="http://ux.edx.org/" class="btn">View the UX Pattern Library</a>
+    <a href="http://ux.edx.org/" class="btn-neutral">View the UX Pattern Library</a>
+    <a href="http://ux.edx.org/" class="btn-brand">View the UX Pattern Library</a>
+    <a href="http://ux.edx.org/" class="btn-elevated">View the UX Pattern Library</a>
+</div>
+
+<h3 class="example-set-hd">Links without visual styling</h3>
+<div class="example-set">
+    <button type="button" class="btn-link">Link</button>
+    <button type="button" class="btn-link btn-large">Link Large</button>
+    <button type="button" class="btn-link btn-small">Link Small</button>
 </div>

--- a/pldoc/static/sass/_components.scss
+++ b/pldoc/static/sass/_components.scss
@@ -610,7 +610,10 @@
 // buttons
 .pldoc-pattern-buttons {
 
-    .btn {
+    .btn,
+    .btn-neutral,
+    .btn-brand,
+    .btn-elevated {
         display: inline-block;
         vertical-align: middle;
         margin-right: spacing-horizontal(x-small);


### PR DESCRIPTION
## Description

I've pushed up some clean ups to the button styles, based upon problems that @rlucioni saw yesterday on Programs. In particular, links styled as buttons were incorrectly showing an underline on hover, and the default button had the wrong color on hover.

I've also reorganized the documentation a little, and pushed up a preview here:

http://ux-test.edx.org/andya/quick-fixes/components/buttons/

## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @clrux 
- [x] @bjacobel 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

FYI @rlucioni @AlasdairSwan @schenedx 