### PR TITLE
Address color contrast issues with form elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jquery": "^1.11.1",
     "requirejs": "^2.1.22",
     "requirejs-plugins": "^1.0.2",
-    "sizzle": "^2.3.0",
+    "sizzle": "2.3.0",
     "susy": "^2.2.9"
   },
   "peerDependencies": {

--- a/pattern-library/sass/patterns/_forms.scss
+++ b/pattern-library/sass/patterns/_forms.scss
@@ -166,12 +166,12 @@ $input-width: (
 .field-input,
 .field-select,
 .field-textarea {
-    @include placeholder { color: palette(grayscale, back); }
+    @include placeholder { color: palette(grayscale, accent); }
     @include transition(all timing(xx-fast) ease-in-out 0s);
     display: inline-block;
     padding: rem($baseline/2);
     border: 1px solid palette(grayscale, back);
-    background: palette(grayscale, x-back);
+    background: $white;
     font-size: font-size(base);
     color: palette(grayscale, dark);
 
@@ -241,7 +241,7 @@ $input-width: (
 .input-text {
 
     &.input-alt {
-        padding: spacing-verical(small) 0;
+        padding: spacing-vertical(small) 0;
         border-width: 0 0 2px 0;
         background: $white;
 


### PR DESCRIPTION
## Description

[TNL-5188](https://openedx.atlassian.net/browse/TNL-5188)

These are a couple of small fixes to the Pattern Library to fix color contrast issues with form elements. Once this lands and is released, I will need to cut a PR against the edx-platform release candidate.

You can see the updated documentation here:

http://ux-test.edx.org/andya/fix-input-background-colors/components/forms/
  
## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [ ] @bjacobel 
- [ ] @clrux 

FYI: @macdiesel @AlasdairSwan 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
