### PR TITLE
Configure Zappr (pull request approval bot)

### DIFF
--- a/.zappr.yml
+++ b/.zappr.yml
@@ -1,0 +1,30 @@
+approvals:
+  ignore: pr_opener  # cannot approve a PR you opened
+  pattern: "(:\+1:|:thumbsup:|:shipit:|lgtm|LGTM)"  # :+1:, :thumbsup:, :shipit:, lgtm or LGTM
+  minimum: 3  # Need UX, engineering and a11y approval
+  groups:
+    # at least 1 approval from UX
+    ux:
+      minimum: 1
+      from:
+        users:
+          - chris-mike
+          - roderickmorales
+          - lizc577
+    # at least 1 approval from FedX engineers
+    engineering:
+      minimum: 1
+      from:
+        users:
+          - andy-armstrong
+          - AlasdairSwan
+          - alisan617
+          - bjacobel
+          - dsjen
+    # at least 1 approval from a11y
+    a11y:
+      minimum: 1
+      from:
+        users:
+          - clrux
+          - cptvitamin

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Dennis Jen <djen@edx.org>
 Andy Armstrong <andya@edx.org>
 Alasdair Swan <aswan@edx.org>
 Alisan Tang <atang@edx.org>
+Brian Jacobel <bjacobel@edx.org>


### PR DESCRIPTION
Adds config for [Zappr](https://zappr.opensource.zalan.do), a system for enforcing the pull request approval process. After this merges (and I flip the switch on their site), every PR will require at least one person from each of the following groups to give their approval.

__UX__
- @chris-mike
- @roderickmorales
- @lizc577

__FedX engineers__
- @andy-armstrong
- @AlasdairSwan
- @alisan617
- @bjacobel
- @dsjen

__a11y__
- @clrux
- @cptvitamin 

Let me know if I forgot anyone (basing this off the org charts).

Approval is given with one of the following phrases:
- :thumbsup: (`:thumbsup:`)
- :+1: (`:+1:`)
- :shipit: (`:shipit:`)
- "LGTM" or "lgtm"

## Reviewers
Let's try it out - I'll merge this when I have one approval from each of the three groups above. (The bot won't actually work until the config is in master.)