### PR TITLE
searchfield in safari and icon in dropdown menu

### DIFF
--- a/pattern-library/js/select-replace.js
+++ b/pattern-library/js/select-replace.js
@@ -20,7 +20,7 @@ define([
             customClass: 'wrapper-custom-select',
             wrapperClass: 'wrapper-replace-select',
             valueClass: 'replace-value',
-            iconClass: 'icon-caret-down',
+            iconClass: 'fa-caret-down',
             hoverClass: 'is-hover'
         },
 
@@ -61,10 +61,8 @@ define([
                             '<select class="' + replaced[0].className + ' is-replaced" id="' + replaced[0].id + '" name="' + replaced[0].name + '" ' + disabled + '>' + replaced[0].innerHTML + '</select>',
                             '<span class="' + variables.customClass + ' ' + statuses.join(' ') + '" aria-hidden="true">',
                                 '<span class="' + variables.valueClass + '">' + CustomSelectReplacement.setInitialText($el) + '</span>',
-                                '<span class="icon-fallback-glyph">',
-                                    '<span class="icon ' + variables.iconClass + '" aria-hidden="true"></span>',
-                                    '<span class="text">Down arrow</span>',
-                                '</span>',
+                                    '<span class="icon fa ' + variables.iconClass + '" aria-hidden="true"></span>',
+                                    '<span class="sr-only">Down arrow</span>',
                             '</span>',
                         '</div>'
                     ].join(''));

--- a/pattern-library/sass/_normalize.scss
+++ b/pattern-library/sass/_normalize.scss
@@ -358,7 +358,19 @@ input[type="search"] {
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box; /* 2 */
   box-sizing: content-box;
+  -webkit-appearance: textfield;
 }
+
+/**
+  * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+  * Safari (but not Chrome) clips the cancel button when the search input has
+  * padding (and `textfield` appearance).
+  */
+ 
+ input[type="search"]::-webkit-search-cancel-button,
+ input[type="search"]::-webkit-search-decoration {
+   -webkit-appearance: none;
+ }
 
 /**
  * Define consistent border, margin, and padding.

--- a/pattern-library/sass/patterns/_forms.scss
+++ b/pattern-library/sass/patterns/_forms.scss
@@ -261,11 +261,15 @@ $input-width: (
     // Input fields immediately followed by a button (ie, search boxes) should eliminate the spacing
     // between them and adopt matching styling/sizing to emphasize that they are connected.
     &[type=search] + button {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        @include border-top-left-radius(0);
+        @include border-bottom-left-radius(0);
+        @include border-top-right-radius(3px);
+        @include border-bottom-right-radius(3px);
+        @include margin-left(-1 * $baseline / 4);
+        @include margin-right(0);
         font-size: font-size(base);
-        margin-left: (-1 * $baseline / 4);
     }
+
 }
 
 
@@ -314,13 +318,7 @@ $input-width: (
         @include size(rem($baseline));
         position: absolute;
         @include right(rem(($baseline/4)));
-        margin-top: rem(-($baseline/10)); // vertically centers the down caret icon
-        color: palette(grayscale, base);
         vertical-align: middle;
-    }
-
-    .icon-fallback-glyph .icon:before {
-        content: "\25BE"; // system glyph down arrow
     }
 
     &:disabled,


### PR DESCRIPTION
## Description

Bug fix only
- Fix RTL margin side of the search button
- Fix the Down Arrow in icon span in dropdown menu
- Fix the search text input box in Safari
   - Remove the -webkit input[type="search" pseudo clear icon in search text input as it does not align well across all browser

[FEDX-228](https://openedx.atlassian.net/browse/FEDX-228)
[FEDX-242](https://openedx.atlassian.net/browse/FEDX-242)
[FEDX-243](https://openedx.atlassian.net/browse/FEDX-243)

## Preview
[Forms](http://ux-test.edx.org/alisan/fix-searchfield-webkit-appearance/components/forms/)
  

## Testing Checklist
- [x] Manually test responsive behavior.
- [x] Manually test a11y support.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @andy-armstrong 
- [x] @bjacobel 


If you've been tagged for review, please check your corresponding box once you've given the :+1:.
<img width="403" alt="before" src="https://cloud.githubusercontent.com/assets/16127998/18488861/3f729628-79c9-11e6-9af5-961351c4ca90.png">
<img width="418" alt="clear-icon" src="https://cloud.githubusercontent.com/assets/16127998/18488868/4454a442-79c9-11e6-86cd-2132bbc9be8f.png">
