### PR TITLE
Reorganize webpack deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "jquery": "^1.11.1",
     "requirejs": "^2.1.22",
     "requirejs-plugins": "^1.0.2",
-    "susy": "^2.2.9",
-    "webpack-dev-server": "^1.15.2"
+    "susy": "^2.2.9"
   },
   "peerDependencies": {
     "font-awesome": "^4.6.3"
@@ -54,7 +53,7 @@
     "text-loader": "0.0.1",
     "url-loader": "^0.5.7",
     "webpack": "~1.12.14",
-    "webpack-stream": "~3.2.0"
+    "webpack-dev-server": "^1.15.2"
   },
   "scripts": {
     "start": "gulp",


### PR DESCRIPTION
Fix two minor issues:

- `webpack-dev-server` was in `dependencies`, not `devDependencies`
- `webpack-stream` was no longer used.