### PR TITLE
Fix issue with prebuilt layouts below 768px

### DIFF
--- a/pattern-library/sass/patterns/_layouts.scss
+++ b/pattern-library/sass/patterns/_layouts.scss
@@ -24,6 +24,10 @@
     }
 }
 
+.layout-col {
+    @include grid-row;
+}
+
 // 1/4 + 3/4 Layout
 .layout-1q3q {
 

--- a/pldoc/_design_elements/grid.md
+++ b/pldoc/_design_elements/grid.md
@@ -346,7 +346,7 @@ info:               A responsive, mobile first fluid grid system based on Flexbo
             </div>
         </div>
     </div>
-</div
+</div>
 
 <h3 class="hd-6 example-set-hd">Utility Class-based Responsive Grid</h3>
 


### PR DESCRIPTION
## Description

Prebuilt layouts at screen sizes < 768 px were broken after my most recent UXPL PR (new grid system).

It's pretty obvious, don't know why I didn't catch it. Live on http://ux.edx.org/design_elements/layouts/

![](https://i.bjacobel.com/20161110-etv0o.png)

Preview sandbox with fix: http://ux-test.edx.org/layouts-responsive-fix/design_elements/layouts/

This will need to go out as 0.17.1 and be integrated into platform before the next release as it's causing [TNL-5934](https://openedx.atlassian.net/browse/TNL-5934)

## Reviewers
- [x] @alisan617 
- [ ] @andy-armstrong

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

