### PR TITLE
Fix overfull grids on colors page

### DIFF
--- a/pldoc/_design_elements/colors.md
+++ b/pldoc/_design_elements/colors.md
@@ -94,7 +94,6 @@ info: These are the predefined colors used throughout our patterns. Each color i
     <div class="example-container">
         <div class="grid-container grid-manual">
             <div class="row">
-                <div class="col col-2"></div>
                 <div class="col col-2 pre-2">
                     <div class="swatch">
                         <div class="color-info">
@@ -382,7 +381,6 @@ info: These are the predefined colors used throughout our patterns. Each color i
     <div class="example-container">
         <div class="grid-container grid-manual">
             <div class="row">
-                <div class="col col-2"></div>
                 <div class="col col-2 pre-2">
                     <div class="swatch">
                         <div class="color-info">
@@ -670,7 +668,6 @@ info: These are the predefined colors used throughout our patterns. Each color i
     <div class="example-container">
         <div class="grid-container grid-manual">
             <div class="row">
-                <div class="col col-2"></div>
                 <div class="col col-2 pre-2">
                     <div class="swatch">
                         <div class="color-info">


### PR DESCRIPTION
## Description

Grids page on UXPL doc was trying to shove 14 columns into a 12-column row for a few of the color sets. (Screenshot below.) This somehow worked in the old grid system, but doesn't anymore.

![](https://i.bjacobel.com/20161116-gd2wj.png)


Fixed on: 
http://ux-test.edx.org/bjacobel/colors-page-grids/design_elements/colors/

## Reviewers
- [ ] @dsjen 
- [ ] @alisan617 
