### PR TITLE
Removed extra column in color page.

### DIFF
--- a/pldoc/_design_elements/colors.md
+++ b/pldoc/_design_elements/colors.md
@@ -94,7 +94,6 @@ info: These are the predefined colors used throughout our patterns. Each color i
     <div class="example-container">
         <div class="grid-container grid-manual">
             <div class="row">
-                <div class="col col-2"></div>
                 <div class="col col-2 pre-2">
                     <div class="swatch">
                         <div class="color-info">


### PR DESCRIPTION
## Description

Removed an extra column in the pattern library doc site so that the column headings are aligned.

**Current layout**
![screen shot 2016-11-16 at 3 27 44 pm](https://cloud.githubusercontent.com/assets/5265058/20364592/b4e25888-ac11-11e6-9692-fc6d2a26357e.png)

**Fixed layout**
![screen shot 2016-11-16 at 3 27 34 pm](https://cloud.githubusercontent.com/assets/5265058/20364587/b01da0dc-ac11-11e6-9358-8473fff08b75.png)
  
## Testing Checklist
- [ ] Manually test responsive behavior.
- [ ] Manually test right-to-left behavior.
- [ ] Manually test a11y support.

## Non-testing Checklist
- [ ] Consider any documentation your change might need, and which users will be affected by this change.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [ ] @alisan617 
- [ ] @bjacobel 
- [ ] @andy-armstrong 
- [ ] @thallada 
- [ ] @AlasdairSwan 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

I'll merge when I hit two approvals 👍 .