### PR TITLE
Disallow installation of bourbon >= 4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bi-app-sass": "^1.1.0",
-    "bourbon": "^4.2.6",
+    "bourbon": "~4.2.7",
     "breakpoint-sass": "^2.6.1",
     "font-awesome": "^4.6.3",
     "jquery": "^1.11.1",


### PR DESCRIPTION
Bourbon 4.3.0 adds a bunch of deprecation warnings for features that will be removed in Bourbon 5.0. These warnings cause _tons_ of unhelpful logging output - [24,000 lines of log spew](https://openedx.atlassian.net/browse/FEDX-287?focusedCommentId=246690&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-246690) for some testing runs.

I don't expect us to update to Bourbon 5.0 any time soon (it's probably more likely that we'd remove Bourbon rather than using it in the coming new iteration of the pattern library) so this just pins the version down to < 4.3.

(Note that there are still some deprecation warnings output using Bourbon 4.2.7 when running `paver compile_sass` in platform, but it's like 12 warnings vs. thousands of them. I'll follow this up in platform to fix those issues.)