### PR TITLE
Fix hyperlinks in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Contributions are very welcome. The easiest way is to fork this repo, and then
 make a pull request from your fork. The first time you make a pull request, you
 may be asked to sign a Contributor Agreement.
 
-Please refer to our [contributor guidelines](https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst) in the main edx-platform repo for
+Please refer to our [contributor guidelines](https://github.com/openedx/.github/blob/master/CONTRIBUTING.md) in the main edx-platform repo for
 important additional information.
 
 ### Contributing and the edX Pattern Library

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ var path = require('path'),
 
     // Config specifically for webpack-dev-server (appended to main config in local development)
     devServerConfig = {
-        // enables Hot Module Replacement (https://webpack.github.io/docs/hot-module-replacement-with-webpack.html)
+        // enables Hot Module Replacement (https://webpack.js.org/guides/hot-module-replacement/)
         hot: true,
         publicPath: '/public',
 
@@ -41,7 +41,7 @@ var path = require('path'),
 
                 // Webpack 'chunks' are a loading mechanism for common code, more chunks can improve perf (esp. with H2)
                 // There is more optimization to be done here! For more see:
-                // https://webpack.github.io/docs/code-splitting.html
+                // https://webpack.js.org/guides/code-splitting/
                 chunkFilename: 'chunk.[id].js'
             },
             entry: {
@@ -102,7 +102,7 @@ var path = require('path'),
         // In prod mode, we disable HMR and use ExtractTextPlugin to generate .css files, avoiding a FOUC
         if (options.debug) {
             // For more on this WDS/HMR configuration, see:
-            // http://webpack.github.io/docs/webpack-dev-server.html#hot-module-replacement
+            // https://webpack.js.org/guides/hot-module-replacement/
             wpconfig.entry['pattern-library-doc'] = [].concat(
                 'webpack-dev-server/client?http://localhost:8080',
                 'webpack/hot/only-dev-server',


### PR DESCRIPTION
## Description

There are multiple broken links in this project. Here is what I have fixed:

https://webpack.github.io/docs/hot-module-replacement-with-webpack.html --> https://webpack.js.org/guides/hot-module-replacement/

https://webpack.github.io/docs/code-splitting.html --> https://webpack.js.org/guides/code-splitting/

https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst --> https://github.com/openedx/.github/blob/master/CONTRIBUTING.md

## Non-testing Checklist
- [x] Consider any documentation your change might need, and which users will be affected by this change.

## Post-review
- [X] Squash commits into discrete sets of changes with descriptive commit messages.

## Support my work

These links were found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐
